### PR TITLE
WIP: Support 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
   - 0.5
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
-julia 0.4
+julia 0.5
 ToeplitzMatrices 0.1
-Compat 0.8.4

--- a/src/ChebyshevJacobiPlan.jl
+++ b/src/ChebyshevJacobiPlan.jl
@@ -140,7 +140,7 @@ function ForwardChebyshevJacobiPlan{T}(c_jac::AbstractVector{T},α::T,β::T,M::I
     @inbounds for i=1:N+1 tempcosβsinα[i] = tempcos[i]^(β+1/2)*tempsin[i]^(α+1/2) end
 
     # Initialize normalizing constant
-    cnαβ = Cnαβ.(0:N,α,β)
+    cnαβ = Cnαβ(0:N,α,β)
     cnmαβ = zero(cnαβ)
 
     # Get indices
@@ -182,11 +182,11 @@ function BackwardChebyshevJacobiPlan{T}(c_cheb::AbstractVector{T},α::T,β::T,M:
     @inbounds for i=1:2N+1 tempcosβsinα[i] = tempcos[i]^(β+1/2)*tempsin[i]^(α+1/2) end
 
     # Initialize normalizing constant
-    cnαβ = Cnαβ.(0:2N,α,β)
+    cnαβ = Cnαβ(0:2N,α,β)
     cnmαβ = zero(cnαβ)
 
     # Initialize orthonormality constants
-    anαβ = Anαβ.(0:N,α,β)
+    anαβ = Anαβ(0:N,α,β)
 
     # Get indices
     CJI = ChebyshevJacobiIndices(α,β,CJC,tempmindices,cfs,tempcos,tempsin,tempcosβsinα)

--- a/src/ChebyshevJacobiPlan.jl
+++ b/src/ChebyshevJacobiPlan.jl
@@ -134,7 +134,7 @@ function ForwardChebyshevJacobiPlan{T}(c_jac::AbstractVector{T},α::T,β::T,M::I
     θ = N > 0 ? T[k/N for k=zero(T):N] : T[0]
 
     # Initialize sines and cosines
-    tempsin = sinpi(θ/2)
+    tempsin = sinpi.(θ./2)
     tempcos = reverse(tempsin)
     tempcosβsinα,tempmindices = zero(c_jac),zero(c_jac)
     @inbounds for i=1:N+1 tempcosβsinα[i] = tempcos[i]^(β+1/2)*tempsin[i]^(α+1/2) end
@@ -176,7 +176,7 @@ function BackwardChebyshevJacobiPlan{T}(c_cheb::AbstractVector{T},α::T,β::T,M:
     w = N > 0 ? clenshawcurtisweights(2N+1,α,β,p₁) : T[0]
 
     # Initialize sines and cosines
-    tempsin = sinpi(θ/2)
+    tempsin = sinpi.(θ./2)
     tempcos = reverse(tempsin)
     tempcosβsinα,tempmindices = zero(c_cheb2),zero(c_cheb2)
     @inbounds for i=1:2N+1 tempcosβsinα[i] = tempcos[i]^(β+1/2)*tempsin[i]^(α+1/2) end

--- a/src/ChebyshevJacobiPlan.jl
+++ b/src/ChebyshevJacobiPlan.jl
@@ -140,7 +140,7 @@ function ForwardChebyshevJacobiPlan{T}(c_jac::AbstractVector{T},α::T,β::T,M::I
     @inbounds for i=1:N+1 tempcosβsinα[i] = tempcos[i]^(β+1/2)*tempsin[i]^(α+1/2) end
 
     # Initialize normalizing constant
-    cnαβ = Cnαβ(0:N,α,β)
+    cnαβ = Cnαβ.(0:N,α,β)
     cnmαβ = zero(cnαβ)
 
     # Get indices
@@ -182,11 +182,11 @@ function BackwardChebyshevJacobiPlan{T}(c_cheb::AbstractVector{T},α::T,β::T,M:
     @inbounds for i=1:2N+1 tempcosβsinα[i] = tempcos[i]^(β+1/2)*tempsin[i]^(α+1/2) end
 
     # Initialize normalizing constant
-    cnαβ = Cnαβ(0:2N,α,β)
+    cnαβ = Cnαβ.(0:2N,α,β)
     cnmαβ = zero(cnαβ)
 
     # Initialize orthonormality constants
-    anαβ = Anαβ(0:N,α,β)
+    anαβ = Anαβ.(0:N,α,β)
 
     # Get indices
     CJI = ChebyshevJacobiIndices(α,β,CJC,tempmindices,cfs,tempcos,tempsin,tempcosβsinα)

--- a/src/ChebyshevUltrasphericalPlan.jl
+++ b/src/ChebyshevUltrasphericalPlan.jl
@@ -139,7 +139,7 @@ function ForwardChebyshevUltrasphericalPlan{T}(c_ultra::AbstractVector{T},λ::T,
     tempsinλm = similar(tempsinλ)
 
     # Initialize normalizing constant
-    cnλ = Cnλ.(0:N,λ)  # broadcast is overloaded
+    cnλ = Cnλ(0:N,λ)
     cnmλ = similar(cnλ)
 
     # Get indices
@@ -180,7 +180,7 @@ function BackwardChebyshevUltrasphericalPlan{T}(c_ultra::AbstractVector{T},λ::T
     tempsinλm = similar(tempsinλ)
 
     # Initialize normalizing constant
-    cnλ = Cnλ.(0:2N,λ) # broadcast is overloaded
+    cnλ = Cnλ(0:2N,λ)
     cnmλ = similar(cnλ)
 
     # Initialize orthonormality constants

--- a/src/ChebyshevUltrasphericalPlan.jl
+++ b/src/ChebyshevUltrasphericalPlan.jl
@@ -139,7 +139,7 @@ function ForwardChebyshevUltrasphericalPlan{T}(c_ultra::AbstractVector{T},λ::T,
     tempsinλm = similar(tempsinλ)
 
     # Initialize normalizing constant
-    cnλ = Cnλ(0:N,λ)
+    cnλ = Cnλ.(0:N,λ)  # broadcast is overloaded
     cnmλ = similar(cnλ)
 
     # Get indices
@@ -180,7 +180,7 @@ function BackwardChebyshevUltrasphericalPlan{T}(c_ultra::AbstractVector{T},λ::T
     tempsinλm = similar(tempsinλ)
 
     # Initialize normalizing constant
-    cnλ = Cnλ(0:2N,λ)
+    cnλ = Cnλ.(0:2N,λ) # broadcast is overloaded
     cnmλ = similar(cnλ)
 
     # Initialize orthonormality constants

--- a/src/ChebyshevUltrasphericalPlan.jl
+++ b/src/ChebyshevUltrasphericalPlan.jl
@@ -131,9 +131,9 @@ function ForwardChebyshevUltrasphericalPlan{T}(c_ultra::AbstractVector{T},λ::T,
     θ = N > 0 ? T[k/N for k=zero(T):N] : T[0]
 
     # Initialize sines and cosines
-    tempsin = sinpi(θ)
+    tempsin = sinpi.(θ)
     @inbounds for i = 1:N÷2 tempsin[N+2-i] = tempsin[i] end
-    tempsin2 = sinpi(θ/2)
+    tempsin2 = sinpi.(θ./2)
     tempsinλ,tempmindices = zero(c_ultra),zero(c_ultra)
     @inbounds for i=1:N+1 tempsinλ[i] = tempsin[i]^λ end
     tempsinλm = similar(tempsinλ)
@@ -172,9 +172,9 @@ function BackwardChebyshevUltrasphericalPlan{T}(c_ultra::AbstractVector{T},λ::T
     w = N > 0 ? clenshawcurtisweights(2N+1,λ-half(λ),λ-half(λ),p₁) : T[0]
 
     # Initialize sines and cosines
-    tempsin = sinpi(θ)
+    tempsin = sinpi.(θ)
     @inbounds for i = 1:N tempsin[2N+2-i] = tempsin[i] end
-    tempsin2 = sinpi(θ/2)
+    tempsin2 = sinpi.(θ/2)
     tempsinλ,tempmindices = zero(c_cheb2),zero(c_cheb2)
     @inbounds for i=1:2N+1 tempsinλ[i] = tempsin[i]^λ end
     tempsinλm = similar(tempsinλ)

--- a/src/FastTransforms.jl
+++ b/src/FastTransforms.jl
@@ -1,10 +1,10 @@
 __precompile__()
 module FastTransforms
 
-using Base, ToeplitzMatrices, Compat
+using Base, ToeplitzMatrices
 
 import Base: *
-import Compat: view
+import Base: view
 
 export cjt, icjt, jjt, plan_cjt, plan_icjt
 export leg2cheb, cheb2leg, leg2chebu, ultra2ultra, jac2jac
@@ -53,5 +53,5 @@ include("gaunt.jl")
 
 include("precompile.jl")
 _precompile_()
- 
+
 end # module

--- a/src/FastTransforms.jl
+++ b/src/FastTransforms.jl
@@ -3,7 +3,8 @@ module FastTransforms
 
 using Base, ToeplitzMatrices
 
-import Base: *, view, broadcast
+import Base: *
+import Base: view
 
 export cjt, icjt, jjt, plan_cjt, plan_icjt
 export leg2cheb, cheb2leg, leg2chebu, ultra2ultra, jac2jac

--- a/src/FastTransforms.jl
+++ b/src/FastTransforms.jl
@@ -3,8 +3,7 @@ module FastTransforms
 
 using Base, ToeplitzMatrices
 
-import Base: *
-import Base: view
+import Base: *, view, broadcast
 
 export cjt, icjt, jjt, plan_cjt, plan_icjt
 export leg2cheb, cheb2leg, leg2chebu, ultra2ultra, jac2jac

--- a/src/PaduaTransform.jl
+++ b/src/PaduaTransform.jl
@@ -194,7 +194,7 @@ Returns coordinates of the (n+1)(n+2)/2 Padua points.
 """
 function paduapoints{T}(::Type{T},n::Integer)
     N=div((n+1)*(n+2),2)
-    MM=Array(T,N,2)
+    MM=Matrix{T}(N,2)
     m=0
     delta=0
     NN=fld(n+2,2)

--- a/src/cjt.jl
+++ b/src/cjt.jl
@@ -101,7 +101,7 @@ end
 
 function *{D,T<:AbstractFloat}(p::FastTransformPlan{D,T},c::AbstractVector{Complex{T}})
     cr,ci = reim(c)
-    complex(p*cr,p*ci)
+    complex.(p*cr,p*ci)
 end
 
 function *(p::FastTransformPlan,c::AbstractMatrix)

--- a/src/fftBigFloat.jl
+++ b/src/fftBigFloat.jl
@@ -104,7 +104,8 @@ end
 function Base.dct(a::AbstractArray{Complex{BigFloat}})
 	N = big(length(a))
     c = fft([a; flipdim(a,1)])
-    d = c[1:N] .* exp(-im*big(pi)*(0:N-1)/(2*N))
+    d = c[1:N]
+    d .*= exp.((-im*big(pi)).*(0:N-1)./(2*N))
     d[1] = d[1] / sqrt(big(2))
     scale!(inv(sqrt(2N)), d)
 end
@@ -115,7 +116,7 @@ function Base.idct(a::AbstractArray{Complex{BigFloat}})
     N = big(length(a))
     b = a * sqrt(2*N)
     b[1] = b[1] * sqrt(big(2))
-    b = b .* exp(im*big(pi)*(0:N-1)/(2*N))
+    b .*= exp.((im*big(pi)).*(0:N-1)./(2*N))
     b = [b; 0; conj(flipdim(b[2:end],1))]
     c = ifft(b)
     c[1:N]
@@ -151,8 +152,8 @@ for (Plan,ff,ff!) in ((:DummyFFTPlan,:fft,:fft!),
                       (:DummyDCTPlan,:dct,:dct!),
                       (:DummyiDCTPlan,:idct,:idct!))
     @eval begin
-        *{T,N}(p::$Plan{T,true}, x::StridedArray{T,N})=$ff!(x)
-        *{T,N}(p::$Plan{T,false}, x::StridedArray{T,N})=$ff(x)
+        *{T,N}(p::$Plan{T,true}, x::StridedArray{T,N}) = $ff!(x)
+        *{T,N}(p::$Plan{T,false}, x::StridedArray{T,N}) = $ff(x)
         function Base.A_mul_B!(C::StridedVector,p::$Plan,x::StridedVector)
             C[:]=$ff(x)
             C

--- a/src/fftBigFloat.jl
+++ b/src/fftBigFloat.jl
@@ -10,7 +10,7 @@ function Base.fft{T<:BigFloats}(x::Vector{T})
     n = length(x)
     ispow2(n) && return fft_pow2(x)
     ks = linspace(zero(real(T)),n-one(real(T)),n)
-    Wks = exp(-im*convert(T,π)*ks.^2/n)
+    Wks = exp.((-im).*convert(T,π).*ks.^2./n)
     xq,wq = x.*Wks,conj([exp(-im*convert(T,π)*n);reverse(Wks);Wks[2:end]])
     return Wks.*conv(xq,wq)[n+1:2n]
 end
@@ -90,14 +90,14 @@ end
 function fft_pow2{T<:BigFloat}(x::Vector{Complex{T}})
     y = interlace(real(x),imag(x))
     fft_pow2!(y)
-    return complex(y[1:2:end],y[2:2:end])
+    return complex.(y[1:2:end],y[2:2:end])
 end
 fft_pow2{T<:BigFloat}(x::Vector{T}) = fft_pow2(complex(x))
 
 function ifft_pow2{T<:BigFloat}(x::Vector{Complex{T}})
     y = interlace(real(x),-imag(x))
     fft_pow2!(y)
-    return complex(y[1:2:end],-y[2:2:end])/length(x)
+    return complex.(y[1:2:end],-y[2:2:end])/length(x)
 end
 
 

--- a/src/specialfunctions.jl
+++ b/src/specialfunctions.jl
@@ -24,7 +24,7 @@ two{T<:Number}(::Type{T}) = convert(T,2)
 The Kronecker δ function.
 """
 δ(k::Integer,j::Integer) = k == j ? 1 : 0
-@vectorize_2arg Integer δ
+
 
 """
 Pochhammer symbol (x)_n = Γ(x+n)/Γ(x) for the rising factorial.
@@ -96,7 +96,7 @@ function stirlingseries(z::Float64)
     end
 end
 
-@vectorize_1arg Number stirlingseries
+
 
 stirlingremainder(z::Number,N::Int) = (1+zeta(N))*gamma(N)/((2π)^(N+1)*z^N)/stirlingseries(z)
 stirlingremainder{T<:Number}(z::AbstractVector{T},N::Int) = (1+zeta(N))*gamma(N)/(2π)^(N+1)./z.^N./stirlingseries(z)
@@ -152,7 +152,7 @@ function Λ(x::Float64)
         (x+1.0)*Λ(x+1.0)/(x+0.5)
     end
 end
-@vectorize_1arg Number Λ
+
 
 """
 The Lambda function Λ(z,λ₁,λ₂) = Γ(z+λ₁)/Γ(z+λ₂) for the ratio of gamma functions.

--- a/src/specialfunctions.jl
+++ b/src/specialfunctions.jl
@@ -165,11 +165,12 @@ function Λ(x::Float64,λ₁::Float64,λ₂::Float64)
         (x+λ₂)/(x+λ₁)*Λ(x+1.,λ₁,λ₂)
     end
 end
+Λ{T<:Number}(x::AbstractArray{T},λ₁::Number,λ₂::Number) = promote_type(T,typeof(λ₁),typeof(λ₂))[ Λ(x[i],λ₁,λ₂) for i in eachindex(x) ]
 
 
 Cnλ(n::Integer,λ::Float64) = 2^λ/sqrtpi*Λ(n+λ)
 Cnλ(n::Integer,λ::Number) = 2^λ/sqrt(oftype(λ,π))*Λ(n+λ)
-function broadcast{T<:Integer}(::typeof(Cnλ),n::UnitRange{T},λ::Number)
+function Cnλ{T<:Integer}(n::UnitRange{T},λ::Number)
     ret = Vector{typeof(λ)}(length(n))
     ret[1] = Cnλ(first(n),λ)
     for i=2:length(n)
@@ -178,6 +179,9 @@ function broadcast{T<:Integer}(::typeof(Cnλ),n::UnitRange{T},λ::Number)
     ret
 end
 
+Cnλ{T<:Integer}(n::AbstractVector{T},λ::Number) = [ Cnλ(n[i],λ) for i=1:length(n) ]
+Cnλ{T<:Integer}(n::AbstractMatrix{T},λ::Number) = [ Cnλ(n[i,j],λ) for i=1:size(n,1), j=1:size(n,2) ]
+
 function Cnmλ(n::Integer,m::Integer,λ::Number)
     if m == 0
         Cnλ(n,λ)
@@ -185,6 +189,9 @@ function Cnmλ(n::Integer,m::Integer,λ::Number)
         (λ+m-1)/2/m*(m-λ)/(n+λ+m)*Cnmλ(n,m-1,λ)
     end
 end
+
+Cnmλ{T<:Integer}(n::AbstractVector{T},m::Integer,λ::Number) = [ Cnmλ(n[i],m,λ) for i=1:length(n) ]
+
 
 function Cnαβ(n::Integer,α::Number,β::Number)
     if n==0
@@ -206,6 +213,9 @@ function Cnαβ(n::Integer,α::Float64,β::Float64)
     end
 end
 
+Cnαβ{T<:Integer}(n::AbstractVector{T},α::Number,β::Number) = [ Cnαβ(n[i],α,β) for i=1:length(n) ]
+Cnαβ{T<:Integer}(n::AbstractMatrix{T},α::Number,β::Number) = [ Cnαβ(n[i,j],α,β) for i=1:size(n,1), j=1:size(n,2) ]
+
 function Cnmαβ(n::Integer,m::Integer,α::Number,β::Number)
     if m == 0
         Cnαβ(n,α,β)
@@ -213,6 +223,15 @@ function Cnmαβ(n::Integer,m::Integer,α::Number,β::Number)
         Cnmαβ(n,m-1,α,β)/2(2n+α+β+m+1)
     end
 end
+
+Cnmαβ{T<:Integer}(n::AbstractVector{T},m::Integer,α::Number,β::Number) = [ Cnmαβ(n[i],m,α,β) for i=1:length(n) ]
+Cnmαβ{T<:Integer}(n::AbstractMatrix{T},m::Integer,α::Number,β::Number) = [ Cnmαβ(n[i,j],m,α,β) for i=1:size(n,1), j=1:size(n,2) ]
+
+function Cnmαβ{T<:Number}(n::Integer,m::Integer,α::AbstractArray{T},β::AbstractArray{T})
+    shp = promote_shape(size(α),size(β))
+    reshape([ Cnmαβ(n,m,α[i],β[i]) for i in eachindex(α,β) ], shp)
+end
+
 
 function absf(α::Number,β::Number,m::Int,θ::Number)
     ret = zero(θ)
@@ -222,7 +241,12 @@ function absf(α::Number,β::Number,m::Int,θ::Number)
     ret
 end
 
-function broadcast{T<:Number}(::typeof(absf),α::Number,β::Number,m::Int,θ::AbstractArray{T,1})
+function absf{T<:Number}(α::AbstractArray{T},β::AbstractArray{T},m::Int,θ::Number)
+    shp = promote_shape(size(α),size(β))
+    reshape([ absf(α[i],β[i],m,θ) for i in eachindex(α,β) ], shp)
+end
+
+function absf{T<:Number}(α::Number,β::Number,m::Int,θ::AbstractArray{T,1})
     ret = zero(θ)
     cfs = zeros(T,m+1)
     for l=0:m
@@ -233,6 +257,8 @@ function broadcast{T<:Number}(::typeof(absf),α::Number,β::Number,m::Int,θ::Ab
     end
     ret
 end
+absf{T<:Number}(α::Number,β::Number,m::Int,θ::AbstractArray{T,2}) = [ absf(α,β,m,θ[i,j]) for i=1:size(θ,1), j=1:size(θ,2) ]
+absf{T<:Number}(α::Number,β::Number,m::Int,θ::AbstractArray{T}) = reshape([ absf(α,β,m,θ[i]) for i in eachindex(θ) ], size(θ))
 
 function compute_absf!{T<:AbstractFloat}(ret::Vector{T},cfs::Matrix{T},α::T,β::T,tempcos::Vector{T},tempsin::Vector{T},tempcosβsinα::Vector{T},m::Int)
     @inbounds for i=1:length(ret)

--- a/src/toeplitzhankel.jl
+++ b/src/toeplitzhankel.jl
@@ -34,7 +34,7 @@ function partialchol(H::Hankel)
     v=[H[:,1];vec(H[end,2:end])]
     d=diag(H)
     @assert length(v) ≥ 2n-1
-    reltol=maxabs(d)*eps(eltype(H))*log(n)
+    reltol=maximum(abs,d)*eps(eltype(H))*log(n)
     for k=1:n
         mx,idx=findmax(d)
         if mx ≤ reltol break end
@@ -61,7 +61,7 @@ function partialchol(H::Hankel,D::AbstractVector)
     v=[H[:,1];vec(H[end,2:end])]
     d=diag(H).*D.^2
     @assert length(v) ≥ 2n-1
-    reltol=maxabs(d)*eps(T)*log(n)
+    reltol=maximum(abs,d)*eps(T)*log(n)
     for k=1:n
         mx,idx=findmax(d)
         if mx ≤ reltol break end

--- a/src/toeplitzhankel.jl
+++ b/src/toeplitzhankel.jl
@@ -99,7 +99,7 @@ end
 # Diagonally-scaled Toeplitz∘Hankel polynomial transforms
 
 function leg2chebTH{S}(::Type{S},n)
-    λ = Λ(0:half(S):n-1)
+    λ = Λ.(0:half(S):n-1)
     t = zeros(S,n)
     t[1:2:end] = λ[1:2:n]
     T = TriangularToeplitz(2t/π,:U)
@@ -122,9 +122,9 @@ function cheb2legTH{S}(::Type{S},n)
 end
 
 function leg2chebuTH{S}(::Type{S},n)
-    λ = Λ(0:half(S):n-1)
+    λ = Λ.(0:half(S):n-1)
     t = zeros(S,n)
-    t[1:2:end] = λ[1:2:n]./(((1:2:n)-2))
+    t[1:2:end] = λ[1:2:n]./(((1:2:n).-2))
     T = TriangularToeplitz(-2t/π,:U)
     H = Hankel(λ[1:n]./((1:n)+1),λ[n:end]./((n:2n-1)+1))
     T,H

--- a/test/fftBigFloattest.jl
+++ b/test/fftBigFloattest.jl
@@ -2,8 +2,8 @@ using FastTransforms
 using Base.Test
 
 c = collect(linspace(-big(1.0),1,16))
-@test norm(fft(c) - fft(map(Float64,c))) < 3Float64(norm(c))*eps()
-@test norm(ifft(c) - ifft(map(Float64,c))) < 3Float64(norm(c))*eps()
+@test norm(fft(c) - fft(Float64.(c))) < 3Float64(norm(c))*eps()
+@test norm(ifft(c) - ifft(Float64.(c))) < 3Float64(norm(c))*eps()
 
 c = collect(linspace(-big(1.0),1.0,201))
 @test norm(ifft(fft(c))-c) < 200norm(c)eps(BigFloat)

--- a/test/fftBigFloattest.jl
+++ b/test/fftBigFloattest.jl
@@ -12,9 +12,9 @@ p = plan_dct(c)
 @test norm(dct(c) - p*c) == 0
 
 pi = plan_idct!(c)
-@test norm(pi*dct(c) - c) < 400norm(c)*eps(BigFloat)
+@test norm(pi*dct(c) - c) < 500norm(c)*eps(BigFloat)
 
 @test norm(dct(c)-dct(map(Float64,c)),Inf) < 10eps()
 
-cc = cis(c)
+cc = cis.(c)
 @test norm(dct(cc)-dct(map(Complex{Float64},cc)),Inf) < 10eps()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -190,17 +190,17 @@ include("fftBigFloattest.jl")
 
 println("Testing equivalence of CXN and ASY methods")
 
-for k in round(Int,logspace(1,4,20))
-    r = randn(k)./√(1:k) # Proven 𝒪(√(log N)) error for ASY method.
-    @test_approx_eq leg2cheb(r) cjt(r,0.,0.)
+for k in round.([Int],logspace(1,4,20))
+    r = randn(k)./(√).(1:k) # Proven 𝒪(√(log N)) error for ASY method.
+    @test leg2cheb(r) ≈ cjt(r,0.,0.)
 end
 
-@test_approx_eq leg2chebu([1.0,2,3,4,5])  [0.546875,0.5,0.5390625,1.25,1.3671875]
+@test leg2chebu([1.0,2,3,4,5])  ≈ [0.546875,0.5,0.5390625,1.25,1.3671875]
 
-c = randn(1000)./√(1:1000);
+c = randn(1000)./(√).(1:1000);
 
-@test_approx_eq leg2cheb(cheb2leg(c)) c
-@test_approx_eq cheb2leg(leg2cheb(c)) c
+@test leg2cheb(cheb2leg(c)) ≈ c
+@test cheb2leg(leg2cheb(c)) ≈ c
 
 @test norm(jac2jac(c,0.,√2/2,-1/4,√2/2)-jjt(c,0.,√2/2,-1/4,√2/2),Inf) < 10length(c)*eps()
 
@@ -213,10 +213,10 @@ N=div((n+1)*(n+2),2)
 v=rand(N)  #Length of v is the no. of Padua points
 Pl=plan_paduatransform!(v)
 IPl=plan_ipaduatransform!(v)
-@test_approx_eq Pl*(IPl*copy(v)) v
-@test_approx_eq IPl*(Pl*copy(v)) v
-@test_approx_eq Pl*copy(v) paduatransform(v)
-@test_approx_eq IPl*copy(v) ipaduatransform(v)
+@test Pl*(IPl*copy(v)) ≈ v
+@test IPl*(Pl*copy(v)) ≈ v
+@test Pl*copy(v) ≈ paduatransform(v)
+@test IPl*copy(v) ≈ ipaduatransform(v)
 
 # check that the return vector is NOT reused
 Pl=plan_paduatransform!(v)
@@ -241,7 +241,7 @@ Interpolates a 2d function at a given point using 2d Chebyshev series.
 function paduaeval(f::Function,x::AbstractFloat,y::AbstractFloat,m::Integer,lex)
     T=promote_type(typeof(x),typeof(y))
     M=div((m+1)*(m+2),2)
-    pvals=Array(T,M)
+    pvals=Vector{T}(M)
     p=paduapoints(T,m)
     map!(f,pvals,p[:,1],p[:,2])
     coeffs=paduatransform(pvals,lex)
@@ -257,11 +257,11 @@ m=130
 l=80
 f_m=paduaeval(f_xy,x,y,m,Val{true})
 g_l=paduaeval(g_xy,x,y,l,Val{true})
-@test_approx_eq f_xy(x,y) f_m
-@test_approx_eq g_xy(x,y) g_l
+@test f_xy(x,y) ≈ f_m
+@test g_xy(x,y) ≈ g_l
 
 
 f_m=paduaeval(f_xy,x,y,m,Val{false})
 g_l=paduaeval(g_xy,x,y,l,Val{false})
-@test_approx_eq f_xy(x,y) f_m
-@test_approx_eq g_xy(x,y) g_l
+@test f_xy(x,y) ≈ f_m
+@test g_xy(x,y) ≈ g_l

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,13 +8,13 @@ n = 0:1000_000
 @time FastTransforms.Cnλ(n,λ);
 
 x = linspace(0,20,81);
-@test norm((FastTransforms.Λ(x)-FastTransforms.Λ(big(x)))./FastTransforms.Λ(big(x)),Inf) < 2eps()
+@test norm((FastTransforms.Λ.(x)-FastTransforms.Λ.(big.(x)))./FastTransforms.Λ.(big.(x)),Inf) < 2eps()
 
 x = 0:0.5:10_000
 λ₁,λ₂ = 0.125,0.875
-@test norm((FastTransforms.Λ(x,λ₁,λ₂)-FastTransforms.Λ(big(x),big(λ₁),big(λ₂)))./FastTransforms.Λ(big(x),big(λ₁),big(λ₂)),Inf) < 4eps()
+@test norm((FastTransforms.Λ.(x,λ₁,λ₂).-FastTransforms.Λ.(big.(x),big(λ₁),big(λ₂)))./FastTransforms.Λ.(big.(x),big(λ₁),big(λ₂)),Inf) < 4eps()
 λ₁,λ₂ = 1//3,2//3
-@test norm((FastTransforms.Λ(x,Float64(λ₁),Float64(λ₂))-FastTransforms.Λ(big(x),big(λ₁),big(λ₂)))./FastTransforms.Λ(big(x),big(λ₁),big(λ₂)),Inf) < 4eps()
+@test norm((FastTransforms.Λ.(x,Float64(λ₁),Float64(λ₂))-FastTransforms.Λ.(big.(x),big(λ₁),big(λ₂)))./FastTransforms.Λ.(big.(x),big(λ₁),big(λ₂)),Inf) < 4eps()
 
 n = 0:1000
 α = 0.125
@@ -31,11 +31,11 @@ N = 20
 f(x) = exp(x)
 
 x,w = FastTransforms.fejer1(N,0.,0.)
-@test norm(dot(f(x),w)-2sinh(1)) ≤ 4eps()
+@test norm(dot(f.(x),w)-2sinh(1)) ≤ 4eps()
 x,w = FastTransforms.fejer2(N,0.,0.)
-@test norm(dot(f(x),w)-2sinh(1)) ≤ 4eps()
+@test norm(dot(f.(x),w)-2sinh(1)) ≤ 4eps()
 x,w = FastTransforms.clenshawcurtis(N,0.,0.)
-@test norm(dot(f(x),w)-2sinh(1)) ≤ 4eps()
+@test norm(dot(f.(x),w)-2sinh(1)) ≤ 4eps()
 
 #=
 x = Fun(identity)
@@ -44,11 +44,11 @@ val = sum(g)
 =#
 
 x,w = FastTransforms.fejer1(N,0.25,0.35)
-@test norm(dot(f(x),w)-2.0351088204147243) ≤ 4eps()
+@test norm(dot(f.(x),w)-2.0351088204147243) ≤ 4eps()
 x,w = FastTransforms.fejer2(N,0.25,0.35)
-@test norm(dot(f(x),w)-2.0351088204147243) ≤ 4eps()
+@test norm(dot(f.(x),w)-2.0351088204147243) ≤ 4eps()
 x,w = FastTransforms.clenshawcurtis(N,0.25,0.35)
-@test norm(dot(f(x),w)-2.0351088204147243) ≤ 4eps()
+@test norm(dot(f.(x),w)-2.0351088204147243) ≤ 4eps()
 
 println("Testing the Chebyshev–Jacobi transform")
 
@@ -57,7 +57,7 @@ v = zeros(Nr)
 Na,Nb = 5,5
 V = zeros(Na,Nb)
 
-for N in round(Int,logspace(1,3,3))
+for N in round.(Int,logspace(1,3,3))
     println("")
     println("N = ",N)
     println("")
@@ -117,7 +117,7 @@ c_11 = [1.13031820798497,0.7239875720908708,0.21281687927358628,0.04004015866217
 @test norm(icjt(c_cheb,0.5,0.5)-c_11,Inf) < eps()
 
 
-c = exp(-collect(1:1000)./30)
+c = exp.(collect(1:1000)./(-30))
 
 println("Testing increment/decrement operators for α,β ≤ -0.5")
 
@@ -158,11 +158,11 @@ p1,p2 = plan_cjt(c,α,β),plan_icjt(c,α,β)
 println("Testing for complex coefficients")
 
 α,β = 0.12,0.34
-c = complex(rand(100),rand(100))
+c = complex.(rand(100),rand(100))
 
-@test cjt(c,α,β) == complex(cjt(real(c),α,β),cjt(imag(c),α,β))
-@test icjt(c,α,β) == complex(icjt(real(c),α,β),icjt(imag(c),α,β))
-@test jjt(c,α,β,α,β) == complex(jjt(real(c),α,β,α,β),jjt(imag(c),α,β,α,β))
+@test cjt(c,α,β) == complex.(cjt(real(c),α,β),cjt(imag(c),α,β))
+@test icjt(c,α,β) == complex.(icjt(real(c),α,β),icjt(imag(c),α,β))
+@test jjt(c,α,β,α,β) == complex.(jjt(real(c),α,β,α,β),jjt(imag(c),α,β,α,β))
 @test norm(jjt(c,α,β,α,β)-c,Inf) < 200eps()
 
 println("Testing for Vector{Float32}")
@@ -178,7 +178,7 @@ cL32 = cjt(c32,0.f0,0.f0)
 println("Testing for Matrix of coefficients")
 
 c = rand(100,100)
-@test maxabs(jjt(c,α,β,α,β)-c) < 10000eps()
+@test maximum(abs,jjt(c,α,β,α,β)-c) < 10000eps()
 
 println("Testing Gaunt coefficients")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,7 +57,7 @@ v = zeros(Nr)
 Na,Nb = 5,5
 V = zeros(Na,Nb)
 
-for N in round.(Int,logspace(1,3,3))
+for N in round.([Int],logspace(1,3,3))
     println("")
     println("N = ",N)
     println("")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ n = 0:1000_000
 @time FastTransforms.Cnλ.(n,λ);
 
 x = linspace(0,20,81);
-@test norm((FastTransforms.Λ.(x)-FastTransforms.Λ.(big.(x)))./FastTransforms.Λ.(big.(x)),Inf) < 2eps()
+@test norm((FastTransforms.Λ.(x).-FastTransforms.Λ.(big.(x)))./FastTransforms.Λ.(big.(x)),Inf) < 2eps()
 
 x = 0:0.5:10_000
 λ₁,λ₂ = 0.125,0.875
@@ -20,11 +20,11 @@ n = 0:1000
 α = 0.125
 β = 0.375
 
-@time FastTransforms.Cnαβ(n,α,β);
-@test norm(FastTransforms.Cnαβ(n,α,β)./FastTransforms.Cnαβ(n,big(α),big(β))-1,Inf) < 3eps()
+@time FastTransforms.Cnαβ.(n,α,β);
+@test norm(FastTransforms.Cnαβ.(n,α,β)./FastTransforms.Cnαβ.(n,big(α),big(β))-1,Inf) < 3eps()
 
-@time FastTransforms.Anαβ(n,α,β);
-@test norm(FastTransforms.Anαβ(n,α,β)./FastTransforms.Anαβ(n,big(α),big(β))-1,Inf) < 4eps()
+@time FastTransforms.Anαβ.(n,α,β);
+@test norm(FastTransforms.Anαβ.(n,α,β)./FastTransforms.Anαβ.(n,big(α),big(β))-1,Inf) < 4eps()
 
 
 N = 20

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,8 +4,8 @@ using Base.Test
 println("Testing special functions")
 n = 0:1000_000
 λ = 0.123
-@time FastTransforms.Cnλ.(n,λ);
-@time FastTransforms.Cnλ.(n,λ);
+@time FastTransforms.Cnλ(n,λ);
+@time FastTransforms.Cnλ(n,λ);
 
 x = linspace(0,20,81);
 @test norm((FastTransforms.Λ.(x)-FastTransforms.Λ.(big.(x)))./FastTransforms.Λ.(big.(x)),Inf) < 2eps()
@@ -57,7 +57,7 @@ v = zeros(Nr)
 Na,Nb = 5,5
 V = zeros(Na,Nb)
 
-for N in round.([Int],logspace(1,3,3))
+for N in round.(Int,logspace(1,3,3))
     println("")
     println("N = ",N)
     println("")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,8 +4,8 @@ using Base.Test
 println("Testing special functions")
 n = 0:1000_000
 λ = 0.123
-@time FastTransforms.Cnλ(n,λ);
-@time FastTransforms.Cnλ(n,λ);
+@time FastTransforms.Cnλ.(n,λ);
+@time FastTransforms.Cnλ.(n,λ);
 
 x = linspace(0,20,81);
 @test norm((FastTransforms.Λ.(x)-FastTransforms.Λ.(big.(x)))./FastTransforms.Λ.(big.(x)),Inf) < 2eps()
@@ -57,7 +57,7 @@ v = zeros(Nr)
 Na,Nb = 5,5
 V = zeros(Na,Nb)
 
-for N in round.(Int,logspace(1,3,3))
+for N in round.([Int],logspace(1,3,3))
     println("")
     println("N = ",N)
     println("")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ n = 0:1000_000
 @time FastTransforms.Cnλ.(n,λ);
 
 x = linspace(0,20,81);
-@test norm((FastTransforms.Λ.(x).-FastTransforms.Λ.(big.(x)))./FastTransforms.Λ.(big.(x)),Inf) < 2eps()
+@test norm((FastTransforms.Λ.(x)-FastTransforms.Λ.(big.(x)))./FastTransforms.Λ.(big.(x)),Inf) < 2eps()
 
 x = 0:0.5:10_000
 λ₁,λ₂ = 0.125,0.875
@@ -20,11 +20,11 @@ n = 0:1000
 α = 0.125
 β = 0.375
 
-@time FastTransforms.Cnαβ.(n,α,β);
-@test norm(FastTransforms.Cnαβ.(n,α,β)./FastTransforms.Cnαβ.(n,big(α),big(β))-1,Inf) < 3eps()
+@time FastTransforms.Cnαβ(n,α,β);
+@test norm(FastTransforms.Cnαβ(n,α,β)./FastTransforms.Cnαβ(n,big(α),big(β))-1,Inf) < 3eps()
 
-@time FastTransforms.Anαβ.(n,α,β);
-@test norm(FastTransforms.Anαβ.(n,α,β)./FastTransforms.Anαβ.(n,big(α),big(β))-1,Inf) < 4eps()
+@time FastTransforms.Anαβ(n,α,β);
+@test norm(FastTransforms.Anαβ(n,α,β)./FastTransforms.Anαβ(n,big(α),big(β))-1,Inf) < 4eps()
 
 
 N = 20


### PR DESCRIPTION
This starts supporting 0.6.  I've dropped 0.4 compatibility so that the `f.(x)` syntax can be used.  Are we OK with this change?  (I think `@compat` can restore 0.4 compatibility but I'm not sure it's worth it.)

the BigFloat FFT test fails for some reason: 
```julia
Testing BigFloat support of FFT and DCT methods
Test Failed
  Expression: norm(ifft(fft(c)) - c) < 200 * (norm(c) * eps(BigFloat))
   Evaluated: 3.290907383297889365567835493403282408529556851637210612211926363351574968498589e-13 < 2.841706296661406868731913357740366307573017126122182078005142968265071086475453e-74
ERROR: LoadError: LoadError: There was an error during testing
while loading /Users/solver/.julia/v0.6/FastTransforms/test/fftBigFloattest.jl, in expression starting on line 9
while loading /Users/solver/.julia/v0.6/FastTransforms/test/runtests.jl, in expression starting on line 189
```