### PR TITLE
Support Spherical Harmonics

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ bivariate function at the Padua points on `[-1,1]^2`.
 
 # References:
 
-   1.	N. Hale and A. Townsend. <a href="http://dx.doi.org/10.1137/130932223">A fast, simple, and stable Chebyshev—Legendre transform using and asymptotic formula</a>, SIAM J. Sci. Comput., 36:A148—A167, 2014.
+   1.   B. Alpert and V. Rokhlin. <a href="http://dx.doi.org/10.1137/0912009">A fast algorithm for the evaluation of Legendre expansions</a>, *SIAM J. Sci. Stat. Comput.*, **12**:158—179, 1991.
 
-   2.	R. M. Slevinsky. <a href="http://arxiv.org/abs/1602.02618">On the use of Hahn's asymptotic formula and stabilized recurrence for a fast, simple, and stable Chebyshev—Jacobi transform</a>, arXiv:1602.02618, 2016.
+   2.	N. Hale and A. Townsend. <a href="http://dx.doi.org/10.1137/130932223">A fast, simple, and stable Chebyshev—Legendre transform using and asymptotic formula</a>, *SIAM J. Sci. Comput.*, **36**:A148—A167, 2014.
 
-   3.	A. Townsend, M. Webb, and S. Olver. <a href="http://arxiv.org/abs/1604.07486">Fast polynomial transforms based on Toeplitz and Hankel matrices</a>, arXiv:1604.07486, 2016.
+   3.	R. M. Slevinsky. <a href="https://doi.org/10.1093/imanum/drw070">On the use of Hahn's asymptotic formula and stabilized recurrence for a fast, simple, and stable Chebyshev—Jacobi transform</a>, published online in *IMA J. Numer. Anal.*, 2017.
+
+   4.	A. Townsend, M. Webb, and S. Olver. <a href="http://arxiv.org/abs/1604.07486">Fast polynomial transforms based on Toeplitz and Hankel matrices</a>, arXiv:1604.07486, 2016.

--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ julia> norm(F-H)
 julia> F = sphrandn(Float64, 1024, 1024);
 
 julia> G = sph2fourier(F; sketch = :none);
-Pre-computing thin plan...100%|██████████████████████████████████████████████████| Time: 0:00:04
+Pre-computing...100%|███████████████████████████████████████████| Time: 0:00:04
 
 julia> H = fourier2sph(G; sketch = :none);
-Pre-computing thin plan...100%|██████████████████████████████████████████████████| Time: 0:00:04
+Pre-computing...100%|███████████████████████████████████████████| Time: 0:00:04
 
 julia> norm(F-H)
 1.1510623098225283e-12
@@ -130,6 +130,6 @@ As with other fast transforms, `plan_sph2fourier` saves effort by caching the pr
 
    [4]  R. M. Slevinsky. <a href="https://doi.org/10.1093/imanum/drw070">On the use of Hahn's asymptotic formula and stabilized recurrence for a fast, simple, and stable Chebyshev—Jacobi transform</a>, in press at *IMA J. Numer. Anal.*, 2017.
 
-   [5]  R. M. Slevinsky. <a href="https://arxiv.org/abs/">Fast and backward stable transforms between spherical harmonic expansions and bivariate Fourier series</a>, arXiv, 2017.
+   [5]  R. M. Slevinsky. <a href="https://arxiv.org/abs/1705.05448">Fast and backward stable transforms between spherical harmonic expansions and bivariate Fourier series</a>, arXiv, 2017.
 
    [6]  A. Townsend, M. Webb, and S. Olver. <a href="https://doi.org/10.1090/mcom/3277">Fast polynomial transforms based on Toeplitz and Hankel matrices</a>, in press at *Math. Comp.*, 2017.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The aim of this package is to provide fast orthogonal polynomial transforms that are designed for expansions of functions with any degree of regularity. There are multiple approaches to the classical connection problem, though the user does not need to know the specifics.
 
-One approach is based on the use of asymptotic formulae to relate the transforms to a small number of fast Fourier transforms. Another approach is based on a Toeplitz-dot-Hankel decomposition of the matrix of connection coefficients. Yet another approach uses a hierarchical decomposition of the matrix of connection coefficients.
+One approach is based on the use of asymptotic formulae to relate the transforms to a small number of fast Fourier transforms. Another approach is based on a Toeplitz-dot-Hankel decomposition of the matrix of connection coefficients. Alternatively, the matrix of connection coefficients may be decomposed hierarchically à la Fast Multipole Method.
 
 ## The Chebyshev—Legendre Transform
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,54 @@
 
 [![Build Status](https://travis-ci.org/MikaelSlevinsky/FastTransforms.jl.svg?branch=master)](https://travis-ci.org/MikaelSlevinsky/FastTransforms.jl) [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://MikaelSlevinsky.github.io/FastTransforms.jl/stable) [![](https://img.shields.io/badge/docs-latest-blue.svg)](https://MikaelSlevinsky.github.io/FastTransforms.jl/latest)
 
-The aim of this package is to provide new classes of fast transforms with low
-pre-computation. One approach is based on the use of asymptotic formulae to
-relate the transforms to a small number of fast Fourier transforms. Another
-approach is based on a Toeplitz-dot-Hankel decomposition of the matrix of
-connection coefficients. Both new classes of fast transforms do not
-require large pre-computation for fast execution and they are designed
-to work on expansions of functions with any degree of regularity.
+The aim of this package is to provide fast orthogonal polynomial transforms that are designed for expansions of functions with any degree of regularity. There are multiple approaches to the classical connection problem, though the user does not need to know the specifics.
 
-The Chebyshev—Jacobi transform and its inverse are implemented. This
-allows the fast conversion of Chebyshev expansion coefficients to Jacobi expansion
-coefficients and back.
+One approach is based on the use of asymptotic formulae to relate the transforms to a small number of fast Fourier transforms. Another approach is based on a Toeplitz-dot-Hankel decomposition of the matrix of connection coefficients. Yet another approach uses a hierarchical decomposition of the matrix of connection coefficients.
+
+## The Chebyshev—Legendre Transform
+
+The Chebyshev—Legendre transform allows the fast conversion of Chebyshev expansion coefficients to Legendre expansion coefficients and back.
+
 ```julia
 julia> Pkg.add("FastTransforms")
 
 julia> using FastTransforms
 
+julia> c = rand(10001);
+
+julia> leg2cheb(c);
+
+julia> cheb2leg(c);
+
+julia> norm(cheb2leg(leg2cheb(c))-c)
+5.564168202018823e-13
+```
+
+The implementation separates pre-computation into a type of plan. This type is constructed with either `plan_leg2cheb` or `plan_cheb2leg`. Let's see how much faster it is if we pre-compute.
+
+```julia
+julia> p1 = plan_leg2cheb(c);
+
+julia> p2 = plan_cheb2leg(c);
+
+julia> @time leg2cheb(c);
+  0.082615 seconds (11.94 k allocations: 31.214 MiB, 6.75% gc time)
+
+julia> @time p1*c;
+  0.004297 seconds (6 allocations: 78.422 KiB)
+
+julia> @time cheb2leg(c);
+  0.110388 seconds (11.94 k allocations: 31.214 MiB, 8.16% gc time)
+
+julia> @time p2*c;
+  0.004500 seconds (6 allocations: 78.422 KiB)
+```
+
+## The Chebyshev—Jacobi Transform
+
+The Chebyshev—Jacobi transform allows the fast conversion of Chebyshev expansion coefficients to Jacobi expansion coefficients and back.
+
+```julia
 julia> c = rand(10001);
 
 julia> @time norm(icjt(cjt(c,0.1,-0.2),0.1,-0.2)-c,Inf)
@@ -43,17 +75,58 @@ is valid for the half-open square `(α,β) ∈ (-1/2,1/2]^2`. Therefore, the fas
 when the parameters are inside. If the parameters `(α,β)` are not exceptionally beyond the square,
 then increment/decrement operators are used with linear complexity (and linear conditioning) in the degree.
 
-The Padua transform and its inverse are also implemented thanks to
-[Michael Clarke](https://github.com/MikeAClarke). These are optimized methods
-designed for computing the bivariate Chebyshev coefficients by interpolating a
-bivariate function at the Padua points on `[-1,1]^2`.
+## The Padua Transform
+
+The Padua transform and its inverse are implemented thanks to [Michael Clarke](https://github.com/MikeAClarke). These are optimized methods designed for computing the bivariate Chebyshev coefficients by interpolating a bivariate function at the Padua points on `[-1,1]^2`.
+
+```julia
+julia> n=200;
+
+julia> N=div((n+1)*(n+2),2)
+
+julia> v=rand(N);  #Length of v is the no. of Padua points
+
+julia> @time norm(ipaduatransform(paduatransform(v))-v)
+0.006571 seconds (846 allocations: 1.746 MiB)
+3.123637691861415e-14
+
+```
+
+## The Spherical Harmonic Transform
+
+Let `A` be a matrix of spherical harmonic expansion coefficients arranged by increasing alternating order. Then `sph2fourier` converts the representation into a bivariate Fourier series, and `fourier2sph` converts it back.
+```julia
+julia> A = rand(Float64, 251, 501); FastTransforms.zero_spurious_modes!(A);
+
+julia> B = sph2fourier(A);
+
+julia> C = fourier2sph(B);
+
+julia> norm(A-C)
+
+julia> A = rand(Float64, 1024, 2047); FastTransforms.zero_spurious_modes!(A);
+
+julia> B = sph2fourier(A; sketch = :none);
+Pre-computing thin plan...100%|██████████████████████████████████████████████████| Time: 0:00:04
+
+julia> C = fourier2sph(B; sketch = :none);
+Pre-computing thin plan...100%|██████████████████████████████████████████████████| Time: 0:00:04
+
+julia> norm(A-C)
+1.5062262753260893e-12
+
+```
+
+As with other fast transforms, `plan_sph2fourier` saves effort by caching the pre-computation. Be warned that for dimensions larger than `1000`, this is no small feat!
 
 # References:
 
-   1.   B. Alpert and V. Rokhlin. <a href="http://dx.doi.org/10.1137/0912009">A fast algorithm for the evaluation of Legendre expansions</a>, *SIAM J. Sci. Stat. Comput.*, **12**:158—179, 1991.
+   [1]  B. Alpert and V. Rokhlin. <a href="http://dx.doi.org/10.1137/0912009">A fast algorithm for the evaluation of Legendre expansions</a>, *SIAM J. Sci. Stat. Comput.*, **12**:158—179, 1991.
 
-   2.	N. Hale and A. Townsend. <a href="http://dx.doi.org/10.1137/130932223">A fast, simple, and stable Chebyshev—Legendre transform using and asymptotic formula</a>, *SIAM J. Sci. Comput.*, **36**:A148—A167, 2014.
+   [2]  N. Hale and A. Townsend. <a href="http://dx.doi.org/10.1137/130932223">A fast, simple, and stable Chebyshev—Legendre transform using and asymptotic formula</a>, *SIAM J. Sci. Comput.*, **36**:A148—A167, 2014.
 
-   3.	R. M. Slevinsky. <a href="https://doi.org/10.1093/imanum/drw070">On the use of Hahn's asymptotic formula and stabilized recurrence for a fast, simple, and stable Chebyshev—Jacobi transform</a>, published online in *IMA J. Numer. Anal.*, 2017.
+   [3]  R. M. Slevinsky. <a href="https://doi.org/10.1093/imanum/drw070">On the use of Hahn's asymptotic formula and stabilized recurrence for a fast, simple, and stable Chebyshev—Jacobi transform</a>, published online in *IMA J. Numer. Anal.*, 2017.
 
-   4.	A. Townsend, M. Webb, and S. Olver. <a href="http://arxiv.org/abs/1604.07486">Fast polynomial transforms based on Toeplitz and Hankel matrices</a>, arXiv:1604.07486, 2016.
+   [4]  R. M. Slevinsky. <a href="https://arxiv.org/abs/">Fast and backward stable transforms between spherical harmonic expansions and bivariate Fourier series</a>, arXiv, 2017.
+
+   [5]  A. Townsend, M. Webb, and S. Olver. <a href="http://arxiv.org/abs/1604.07486">Fast polynomial transforms based on Toeplitz and Hankel matrices</a>, arXiv:1604.07486, 2016.

--- a/README.md
+++ b/README.md
@@ -94,26 +94,26 @@ julia> @time norm(ipaduatransform(paduatransform(v))-v)
 
 ## The Spherical Harmonic Transform
 
-Let `A` be a matrix of spherical harmonic expansion coefficients arranged by increasing order in absolute value, alternating between negative and positive. Then `sph2fourier` converts the representation into a bivariate Fourier series, and `fourier2sph` converts it back.
+Let `F` be a matrix of spherical harmonic expansion coefficients arranged by increasing order in absolute value, alternating between negative and positive orders. Then `sph2fourier` converts the representation into a bivariate Fourier series, and `fourier2sph` converts it back.
 ```julia
-julia> A = rand(Float64, 251, 501); FastTransforms.zero_spurious_modes!(A);
+julia> F = rand(Float64, 251, 501); FastTransforms.zero_spurious_modes!(F);
 
-julia> B = sph2fourier(A);
+julia> G = sph2fourier(F);
 
-julia> C = fourier2sph(B);
+julia> H = fourier2sph(G);
 
-julia> norm(A-C)
+julia> norm(F-H)
 7.422366861016818e-14
 
-julia> A = rand(Float64, 1024, 2047); FastTransforms.zero_spurious_modes!(A);
+julia> F = rand(Float64, 1024, 2047); FastTransforms.zero_spurious_modes!(F);
 
-julia> B = sph2fourier(A; sketch = :none);
+julia> G = sph2fourier(F; sketch = :none);
 Pre-computing thin plan...100%|██████████████████████████████████████████████████| Time: 0:00:04
 
-julia> C = fourier2sph(B; sketch = :none);
+julia> H = fourier2sph(G; sketch = :none);
 Pre-computing thin plan...100%|██████████████████████████████████████████████████| Time: 0:00:04
 
-julia> norm(A-C)
+julia> norm(F-H)
 1.5062262753260893e-12
 
 ```

--- a/README.md
+++ b/README.md
@@ -130,6 +130,6 @@ As with other fast transforms, `plan_sph2fourier` saves effort by caching the pr
 
    [4]  R. M. Slevinsky. <a href="https://doi.org/10.1093/imanum/drw070">On the use of Hahn's asymptotic formula and stabilized recurrence for a fast, simple, and stable Chebyshev—Jacobi transform</a>, in press at *IMA J. Numer. Anal.*, 2017.
 
-   [5]  R. M. Slevinsky. <a href="https://arxiv.org/abs/1705.05448">Fast and backward stable transforms between spherical harmonic expansions and bivariate Fourier series</a>, arXiv, 2017.
+   [5]  R. M. Slevinsky. <a href="https://arxiv.org/abs/1705.05448">Fast and backward stable transforms between spherical harmonic expansions and bivariate Fourier series</a>, arXiv:1705.05448, 2017.
 
    [6]  A. Townsend, M. Webb, and S. Olver. <a href="https://doi.org/10.1090/mcom/3277">Fast polynomial transforms based on Toeplitz and Hankel matrices</a>, in press at *Math. Comp.*, 2017.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ julia> @time norm(ipaduatransform(paduatransform(v))-v)
 
 ## The Spherical Harmonic Transform
 
-Let `A` be a matrix of spherical harmonic expansion coefficients arranged by increasing alternating order. Then `sph2fourier` converts the representation into a bivariate Fourier series, and `fourier2sph` converts it back.
+Let `A` be a matrix of spherical harmonic expansion coefficients arranged by increasing order in absolute value, alternating between negative and positive. Then `sph2fourier` converts the representation into a bivariate Fourier series, and `fourier2sph` converts it back.
 ```julia
 julia> A = rand(Float64, 251, 501); FastTransforms.zero_spurious_modes!(A);
 
@@ -103,6 +103,7 @@ julia> B = sph2fourier(A);
 julia> C = fourier2sph(B);
 
 julia> norm(A-C)
+7.422366861016818e-14
 
 julia> A = rand(Float64, 1024, 2047); FastTransforms.zero_spurious_modes!(A);
 
@@ -117,7 +118,7 @@ julia> norm(A-C)
 
 ```
 
-As with other fast transforms, `plan_sph2fourier` saves effort by caching the pre-computation. Be warned that for dimensions larger than `1000`, this is no small feat!
+As with other fast transforms, `plan_sph2fourier` saves effort by caching the pre-computation. Be warned that for dimensions larger than `1,000`, this is no small feat!
 
 # References:
 

--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ then increment/decrement operators are used with linear complexity (and linear c
 The Padua transform and its inverse are implemented thanks to [Michael Clarke](https://github.com/MikeAClarke). These are optimized methods designed for computing the bivariate Chebyshev coefficients by interpolating a bivariate function at the Padua points on `[-1,1]^2`.
 
 ```julia
-julia> n=200;
+julia> n = 200;
 
-julia> N=div((n+1)*(n+2),2)
+julia> N = div((n+1)*(n+2),2);
 
-julia> v=rand(N);  #Length of v is the no. of Padua points
+julia> v = rand(N); # The length of v is the number of Padua points
 
 julia> @time norm(ipaduatransform(paduatransform(v))-v)
 0.006571 seconds (846 allocations: 1.746 MiB)

--- a/README.md
+++ b/README.md
@@ -96,16 +96,16 @@ julia> @time norm(ipaduatransform(paduatransform(v))-v)
 
 Let `F` be a matrix of spherical harmonic expansion coefficients arranged by increasing order in absolute value, alternating between negative and positive orders. Then `sph2fourier` converts the representation into a bivariate Fourier series, and `fourier2sph` converts it back.
 ```julia
-julia> F = rand(Float64, 251, 501); FastTransforms.zero_spurious_modes!(F);
+julia> F = sphrandn(Float64, 256, 256);
 
 julia> G = sph2fourier(F);
 
 julia> H = fourier2sph(G);
 
 julia> norm(F-H)
-7.422366861016818e-14
+4.950645831278297e-14
 
-julia> F = rand(Float64, 1024, 2047); FastTransforms.zero_spurious_modes!(F);
+julia> F = sphrandn(Float64, 1024, 1024);
 
 julia> G = sph2fourier(F; sketch = :none);
 Pre-computing thin plan...100%|██████████████████████████████████████████████████| Time: 0:00:04
@@ -114,7 +114,7 @@ julia> H = fourier2sph(G; sketch = :none);
 Pre-computing thin plan...100%|██████████████████████████████████████████████████| Time: 0:00:04
 
 julia> norm(F-H)
-1.5062262753260893e-12
+1.1510623098225283e-12
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,10 @@ As with other fast transforms, `plan_sph2fourier` saves effort by caching the pr
 
    [2]  N. Hale and A. Townsend. <a href="http://dx.doi.org/10.1137/130932223">A fast, simple, and stable Chebyshev—Legendre transform using and asymptotic formula</a>, *SIAM J. Sci. Comput.*, **36**:A148—A167, 2014.
 
-   [3]  R. M. Slevinsky. <a href="https://doi.org/10.1093/imanum/drw070">On the use of Hahn's asymptotic formula and stabilized recurrence for a fast, simple, and stable Chebyshev—Jacobi transform</a>, published online in *IMA J. Numer. Anal.*, 2017.
+   [3] J. Keiner. <a href="http://dx.doi.org/10.1137/070703065">Computing with expansions in Gegenbauer polynomials</a>, *SIAM J. Sci. Comput.*, **31**:2151—2171, 2009.
 
-   [4]  R. M. Slevinsky. <a href="https://arxiv.org/abs/">Fast and backward stable transforms between spherical harmonic expansions and bivariate Fourier series</a>, arXiv, 2017.
+   [4]  R. M. Slevinsky. <a href="https://doi.org/10.1093/imanum/drw070">On the use of Hahn's asymptotic formula and stabilized recurrence for a fast, simple, and stable Chebyshev—Jacobi transform</a>, in press at *IMA J. Numer. Anal.*, 2017.
 
-   [5]  A. Townsend, M. Webb, and S. Olver. <a href="http://arxiv.org/abs/1604.07486">Fast polynomial transforms based on Toeplitz and Hankel matrices</a>, arXiv:1604.07486, 2016.
+   [5]  R. M. Slevinsky. <a href="https://arxiv.org/abs/">Fast and backward stable transforms between spherical harmonic expansions and bivariate Fourier series</a>, arXiv, 2017.
+
+   [6]  A. Townsend, M. Webb, and S. Olver. <a href="https://doi.org/10.1090/mcom/3277">Fast polynomial transforms based on Toeplitz and Hankel matrices</a>, in press at *Math. Comp.*, 2017.

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,4 +3,4 @@ ToeplitzMatrices 0.2
 HierarchicalMatrices 0.0.1
 LowRankApprox 0.0.2
 ProgressMeter 0.3.4
-Compat 0.18
+Compat 0.17

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,5 @@
 julia 0.5
 ToeplitzMatrices 0.2
-Compat 0.19
+LowRankApprox 0.0.2
+ProgressMeter 0.3.4
+Compat 0.18

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
 julia 0.5
 ToeplitzMatrices 0.2
+HierarchicalMatrices 0.0.1
 LowRankApprox 0.0.2
 ProgressMeter 0.3.4
 Compat 0.18

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.5
 ToeplitzMatrices 0.2
-Compat 0.17
+Compat 0.19

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,6 +18,6 @@ deploydocs(
     julia  = "0.5",
     osname = "linux",
     target = "build",
-    deps   = nothing,
+    deps   = Deps.pip("pygments", "mkdocs", "python-markdown-math"),
     make   = nothing
     )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,7 +6,7 @@ In numerical analysis, it is customary to expand a function in a basis:
 ```math
 f(x) \sim \sum_{\ell=0}^{\infty} f_{\ell} \phi_{\ell}(x).
 ```
-It may be more convenient to transform our representation to one in a new basis, say, ``\{\psi_m(x)\}_{m\ge0}``:
+It may be necessary to transform our representation to one in a new basis, say, ``\{\psi_m(x)\}_{m\ge0}``:
 ```math
 f(x) \sim \sum_{m=0}^{\infty} g_m \psi_m(x).
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,7 +1,45 @@
 # FastTransforms.jl Documentation
 
+## Introduction
+
+In numerical analysis, it is customary to expand a function in a basis:
+```math
+f(x) = \sum_{\ell = 0}^{n} f_{\ell} \phi_{\ell}(x).
+```
+Orthogonal polynomials are examples of convenient bases for sufficiently smooth functions. To perform some operation, it may be necessary to convert our representation to one in a new basis, say, ``\{\psi_m(x)\}_{m\ge0}``.
+
+If each function ``\phi_{\ell}`` is expanded in the basis ``\psi_m``, such as:
+```math
+\phi_{\ell}(x) \sim \sum_{m=0}^{\infty} c_{m,\ell}\psi_{m}(x),
+```
+then our original function has the alternative representation:
+```math
+f(x) \sim \sum_{m = 0}^{\infty} g_m \psi_m(x),
+```
+where ``g_m`` are defined by the sum:
+```math
+g_m = \sum_{\ell = 0}^{n} c_{m,\ell} f_{\ell}.
+```
+
+This is the classical connection problem. In many cases of interest, the both representations are finite and we seek a fast method (faster than ``\mathcal{O}(n^2)``) to transform the coefficients ``f_{\ell}`` to ``g_m``. These are the fast transforms.
 
 ## Fast Transforms
+
+```@docs
+leg2cheb
+```
+
+```@docs
+cheb2leg
+```
+
+```@docs
+plan_leg2cheb
+```
+
+```@docs
+plan_cheb2leg
+```
 
 ```@docs
 cjt
@@ -37,6 +75,18 @@ plan_paduatransform!
 
 ```@docs
 plan_ipaduatransform!
+```
+
+```@docs
+sph2fourier
+```
+
+```@docs
+fourier2sph
+```
+
+```@docs
+plan_sph2fourier
 ```
 
 ## Other Exported Methods

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,24 +4,15 @@
 
 In numerical analysis, it is customary to expand a function in a basis:
 ```math
-f(x) = \sum_{\ell = 0}^{n} f_{\ell} \phi_{\ell}(x).
+f(x) \sim \sum_{\ell=0}^{\infty} f_{\ell} \phi_{\ell}(x).
 ```
-Orthogonal polynomials are examples of convenient bases for sufficiently smooth functions. To perform some operation, it may be necessary to convert our representation to one in a new basis, say, ``\{\psi_m(x)\}_{m\ge0}``.
+It may be more convenient to transform our representation to one in a new basis, say, ``\{\psi_m(x)\}_{m\ge0}``:
+```math
+f(x) \sim \sum_{m=0}^{\infty} g_m \psi_m(x).
+```
+In many cases of interest, both representations are of finite length ``n`` and we seek a fast method (faster than ``\mathcal{O}(n^2)``) to transform the original coefficients ``f_{\ell}`` to the new coefficients ``g_m``.
 
-If each function ``\phi_{\ell}`` is expanded in the basis ``\psi_m``, such as:
-```math
-\phi_{\ell}(x) \sim \sum_{m=0}^{\infty} c_{m,\ell}\psi_{m}(x),
-```
-then our original function has the alternative representation:
-```math
-f(x) \sim \sum_{m = 0}^{\infty} g_m \psi_m(x),
-```
-where ``g_m`` are defined by the sum:
-```math
-g_m = \sum_{\ell = 0}^{n} c_{m,\ell} f_{\ell}.
-```
-
-This is the classical connection problem. In many cases of interest, the both representations are finite and we seek a fast method (faster than ``\mathcal{O}(n^2)``) to transform the coefficients ``f_{\ell}`` to ``g_m``. These are the fast transforms.
+A similar problem arises when we wish to evaluate ``f`` at a set of points ``\{x_m\}_{m=0}^n``. We wish to transform coefficients of ``f`` to values at the set of points in fewer than ``\mathcal{O}(n^2)`` operations.
 
 ## Fast Transforms
 
@@ -97,6 +88,10 @@ gaunt
 
 ```@docs
 paduapoints
+```
+
+```@docs
+sphevaluate
 ```
 
 ## Internal Methods

--- a/src/FastTransforms.jl
+++ b/src/FastTransforms.jl
@@ -1,13 +1,15 @@
 __precompile__()
 module FastTransforms
 
-using Base, ToeplitzMatrices, Compat
+using Base, ToeplitzMatrices, HierarchicalMatrices, Compat
 
-import Base: *
-import Base: view
+import Base: *, view
+
+import HierarchicalMatrices: HierarchicalMatrix
 
 export cjt, icjt, jjt, plan_cjt, plan_icjt
 export leg2cheb, cheb2leg, leg2chebu, ultra2ultra, jac2jac
+export plan_leg2cheb, plan_cheb2leg
 export gaunt
 export paduatransform, ipaduatransform, paduatransform!, ipaduatransform!, paduapoints
 export plan_paduatransform!, plan_ipaduatransform!
@@ -42,11 +44,13 @@ include("cjt.jl")
 
 include("toeplitzhankel.jl")
 
-leg2cheb(x...)=th_leg2cheb(x...)
-cheb2leg(x...)=th_cheb2leg(x...)
+#leg2cheb(x...)=th_leg2cheb(x...)
+#cheb2leg(x...)=th_cheb2leg(x...)
 leg2chebu(x...)=th_leg2chebu(x...)
 ultra2ultra(x...)=th_ultra2ultra(x...)
 jac2jac(x...)=th_jac2jac(x...)
+
+include("hierarchical.jl")
 
 include("gaunt.jl")
 

--- a/src/FastTransforms.jl
+++ b/src/FastTransforms.jl
@@ -3,10 +3,11 @@ module FastTransforms
 
 using Base, ToeplitzMatrices, HierarchicalMatrices, LowRankApprox, ProgressMeter, Compat
 
-import Base: *, \, size, view, A_mul_B!, At_mul_B!, Ac_mul_B!
+import Base: *, \, size, view
 import Base: getindex, setindex!, Factorization, length
 import Base.LinAlg: BlasFloat, BlasInt
 import HierarchicalMatrices: HierarchicalMatrix, unsafe_broadcasttimes!
+import HierarchicalMatrices: A_mul_B!, At_mul_B!, Ac_mul_B!
 import LowRankApprox: ColPerm
 
 export cjt, icjt, jjt, plan_cjt, plan_icjt
@@ -21,6 +22,7 @@ export plan_paduatransform!, plan_ipaduatransform!
 
 export SlowSphericalHarmonicPlan, FastSphericalHarmonicPlan, ThinSphericalHarmonicPlan
 export sph2fourier, fourier2sph, plan_sph2fourier
+export sphones, sphzeros, sphrand, sphrandn, sphevaluate
 
 # Other module methods and constants:
 #export ChebyshevJacobiPlan, jac2cheb, cheb2jac

--- a/src/FastTransforms.jl
+++ b/src/FastTransforms.jl
@@ -3,11 +3,11 @@ module FastTransforms
 
 using Base, ToeplitzMatrices, HierarchicalMatrices, LowRankApprox, ProgressMeter, Compat
 
-import Base: *, size, view, A_mul_B!, At_mul_B!, Ac_mul_B!
+import Base: *, \, size, view, A_mul_B!, At_mul_B!, Ac_mul_B!
 import Base: getindex, setindex!, Factorization, length
 import Base.LinAlg: BlasFloat, BlasInt
 import HierarchicalMatrices: HierarchicalMatrix, unsafe_broadcasttimes!
-import LowRankApprox: rowperm!, ColPerm
+import LowRankApprox: ColPerm
 
 export cjt, icjt, jjt, plan_cjt, plan_icjt
 export leg2cheb, cheb2leg, leg2chebu, ultra2ultra, jac2jac
@@ -20,6 +20,7 @@ export paduatransform, ipaduatransform, paduatransform!, ipaduatransform!, padua
 export plan_paduatransform!, plan_ipaduatransform!
 
 export SlowSphericalHarmonicPlan, FastSphericalHarmonicPlan, ThinSphericalHarmonicPlan
+export sph2fourier, fourier2sph, plan_sph2fourier
 
 # Other module methods and constants:
 #export ChebyshevJacobiPlan, jac2cheb, cheb2jac

--- a/src/FastTransforms.jl
+++ b/src/FastTransforms.jl
@@ -3,13 +3,17 @@ module FastTransforms
 
 using Base, ToeplitzMatrices, HierarchicalMatrices, Compat
 
-import Base: *, view
+import Base: *, size, view, A_mul_B!, Ac_mul_B!, At_mul_B!
+import Base: getindex, setindex!
 
-import HierarchicalMatrices: HierarchicalMatrix
+import HierarchicalMatrices: HierarchicalMatrix, unsafe_broadcasttimes!
 
 export cjt, icjt, jjt, plan_cjt, plan_icjt
 export leg2cheb, cheb2leg, leg2chebu, ultra2ultra, jac2jac
+export normleg2cheb, cheb2normleg, normleg12cheb2, cheb22normleg1
 export plan_leg2cheb, plan_cheb2leg
+export plan_normleg2cheb, plan_cheb2normleg
+export plan_normleg12cheb2, plan_cheb22normleg1
 export gaunt
 export paduatransform, ipaduatransform, paduatransform!, ipaduatransform!, paduapoints
 export plan_paduatransform!, plan_ipaduatransform!
@@ -51,6 +55,7 @@ ultra2ultra(x...)=th_ultra2ultra(x...)
 jac2jac(x...)=th_jac2jac(x...)
 
 include("hierarchical.jl")
+include("SphericalHarmonics/slowplan.jl")
 
 include("gaunt.jl")
 

--- a/src/FastTransforms.jl
+++ b/src/FastTransforms.jl
@@ -1,9 +1,9 @@
 __precompile__()
 module FastTransforms
 
-using Base, ToeplitzMatrices, HierarchicalMatrices, LowRankApprox, Compat
+using Base, ToeplitzMatrices, HierarchicalMatrices, LowRankApprox, ProgressMeter, Compat
 
-import Base: *, size, view, A_mul_B!, Ac_mul_B!, At_mul_B!
+import Base: *, size, view, A_mul_B!, At_mul_B!, Ac_mul_B!
 import Base: getindex, setindex!, Factorization, length
 import Base.LinAlg: BlasFloat, BlasInt
 import HierarchicalMatrices: HierarchicalMatrix, unsafe_broadcasttimes!

--- a/src/FastTransforms.jl
+++ b/src/FastTransforms.jl
@@ -1,12 +1,13 @@
 __precompile__()
 module FastTransforms
 
-using Base, ToeplitzMatrices, HierarchicalMatrices, Compat
+using Base, ToeplitzMatrices, HierarchicalMatrices, LowRankApprox, Compat
 
 import Base: *, size, view, A_mul_B!, Ac_mul_B!, At_mul_B!
-import Base: getindex, setindex!
-
+import Base: getindex, setindex!, Factorization, length
+import Base.LinAlg: BlasFloat, BlasInt
 import HierarchicalMatrices: HierarchicalMatrix, unsafe_broadcasttimes!
+import LowRankApprox: rowperm!, ColPerm
 
 export cjt, icjt, jjt, plan_cjt, plan_icjt
 export leg2cheb, cheb2leg, leg2chebu, ultra2ultra, jac2jac
@@ -55,7 +56,7 @@ ultra2ultra(x...)=th_ultra2ultra(x...)
 jac2jac(x...)=th_jac2jac(x...)
 
 include("hierarchical.jl")
-include("SphericalHarmonics/slowplan.jl")
+include("SphericalHarmonics/SphericalHarmonics.jl")
 
 include("gaunt.jl")
 

--- a/src/FastTransforms.jl
+++ b/src/FastTransforms.jl
@@ -19,6 +19,8 @@ export gaunt
 export paduatransform, ipaduatransform, paduatransform!, ipaduatransform!, paduapoints
 export plan_paduatransform!, plan_ipaduatransform!
 
+export SlowSphericalHarmonicPlan, FastSphericalHarmonicPlan, ThinSphericalHarmonicPlan
+
 # Other module methods and constants:
 #export ChebyshevJacobiPlan, jac2cheb, cheb2jac
 #export sqrtpi, pochhammer, stirlingseries, stirlingremainder, Aratio, Cratio, Anαβ

--- a/src/SphericalHarmonics/Butterfly.jl
+++ b/src/SphericalHarmonics/Butterfly.jl
@@ -1,0 +1,274 @@
+immutable Butterfly{T} <: Factorization{T}
+    columns::Vector{Matrix{T}}
+    factors::Vector{Vector{IDPackedV{T}}}
+    permutations::Vector{Vector{ColumnPermutation}}
+    indices::Vector{Vector{Int64}}
+    temp1::Vector{T}
+    temp2::Vector{T}
+end
+
+function size(B::Butterfly, dim::Integer)
+    if dim == 1
+        m = 0
+        for i = 1:length(B.columns)
+            m += size(B.columns[i], 1)
+        end
+        return m
+    elseif dim == 2
+        n = 0
+        for j = 1:length(B.factors[1])
+            n += size(B.factors[1][j], 2)
+        end
+        return n
+    else
+        return 1
+    end
+end
+
+size(B::Butterfly) = size(B, 1), size(B, 2)
+
+function Butterfly{T}(A::AbstractMatrix{T}, L::Int64)
+    m, n = size(A)
+    tL = 2^L
+
+    LRAOpts = LRAOptions(T; rtol = eps(real(T))*max(m, n))
+
+    columns = Vector{Matrix{T}}(tL)
+    factors = Vector{Vector{IDPackedV{T}}}(L+1)
+    permutations = Vector{Vector{ColumnPermutation}}(L+1)
+    indices = Vector{Vector{Int64}}(L+1)
+    cs = Vector{Vector{Vector{Int64}}}(L+1)
+
+    factors[1] = Vector{IDPackedV{T}}(tL)
+    permutations[1] = Vector{ColumnPermutation}(tL)
+    indices[1] = Vector{Int64}(tL+1)
+    cs[1] = Vector{Vector{Int64}}(tL)
+
+    nd = n÷tL
+    nl = 1
+    nu = nd
+    indices[1][1] = 1
+    for j = 1:tL
+        factors[1][j] = idfact(view(A,:,nl:nu), LRAOpts)
+        permutations[1][j] = factors[1][j][:P]
+        indices[1][j+1] = indices[1][j] + size(factors[1][j], 1)
+        cs[1][j] = factors[1][j].sk+nl-1
+        nl += nd
+        nu += nd
+    end
+
+    ii, jj = 2, (tL>>1)
+    for l = 2:L+1
+        factors[l] = Vector{IDPackedV{T}}(tL)
+        permutations[l] = Vector{ColumnPermutation}(tL)
+        indices[l] = Vector{Int64}(tL+1)
+        cs[l] = Vector{Vector{Int64}}(tL)
+
+        ctr = 0
+        md = m÷ii
+        ml = 1
+        mu = md
+        indices[l][1] = 1
+        for i = 1:ii
+            shft = 2jj*div(ctr,2jj)
+            for j = 1:jj
+                cols = vcat(cs[l-1][2j-1+shft],cs[l-1][2j+shft])
+                factors[l][j+ctr] = idfact(view(A, ml:mu, cols), LRAOpts)
+                permutations[l][j+ctr] = factors[l][j+ctr][:P]
+                indices[l][j+ctr+1] = indices[l][j+ctr] + size(factors[l][j+ctr], 1)
+                cs[l][j+ctr] = cols[factors[l][j+ctr].sk]
+            end
+            ml += md
+            mu += md
+            ctr += jj
+        end
+        ii <<= 1
+        jj >>= 1
+    end
+
+    md = m÷tL
+    ml = 1
+    mu = md
+    for i = 1:tL
+        columns[i] = A[ml:mu,cs[L+1][i]]
+        ml += md
+        mu += md
+    end
+
+    kk = sumkmax(indices)
+
+    Butterfly(columns, factors, permutations, indices, zeros(T, kk), zeros(T, kk))
+end
+
+
+function rowperm!(fwd::Bool, x::StridedVecOrMat, p::Vector{Int}, jstart::Int)
+  n = length(p)
+  jshift = jstart-1
+  scale!(p, -1)
+  if (fwd)
+    for i = 1:n
+      p[i] > 0 && continue
+      j    =    i
+      p[j] = -p[j]
+      k    =  p[j]
+      while p[k] < 0
+        x[jshift+j], x[jshift+k] = x[jshift+k], x[jshift+j]
+        j    =    k
+        p[j] = -p[j]
+        k    =  p[j]
+      end
+    end
+  else
+    for i = 1:n
+      p[i] > 0 && continue
+      p[i] = -p[i]
+      j    =  p[i]
+      while p[j] < 0
+        x[jshift+i], x[jshift+j] = x[jshift+j], x[jshift+i]
+        p[j] = -p[j]
+        j    =  p[j]
+      end
+    end
+  end
+  x
+end
+
+## ColumnPermutation
+A_mul_B!(A::ColPerm, B::StridedVecOrMat, jstart::Int) = rowperm!(false, B, A.p, jstart)
+Ac_mul_B!(A::ColPerm, B::StridedVecOrMat, jstart::Int) = rowperm!(true, B, A.p, jstart)
+
+function A_mul_B!{T<:BlasFloat}(y::AbstractVecOrMat{T}, A::IDPackedV{T}, P::ColumnPermutation, x::AbstractVecOrMat{T}, istart::Int, jstart::Int)
+    k, n = size(A)
+    Ac_mul_B!(P, x, jstart)
+    copy!(y, istart, x, jstart, k)
+    A_mul_B!(y, A.T, x, istart, jstart+k)
+    A_mul_B!(P, x, jstart)
+    y
+end
+
+
+function A_mul_B!{T}(u::Vector{T}, B::Butterfly{T}, b::Vector{T})
+    L = length(B.factors) - 1
+    tL = 2^L
+
+    temp1 = B.temp1
+    temp2 = B.temp2
+    fill!(temp1, zero(T))
+    fill!(temp2, zero(T))
+
+    factors = B.factors[1]
+    permutations = B.permutations[1]
+    inds = B.indices[1]
+    nu = 0
+    for j = 1:tL
+        nl = nu+1
+        nu += size(factors[j], 2)
+        A_mul_B!(temp1, factors[j], permutations[j], b, inds[j], nl)
+    end
+
+    ii, jj = 2, (tL>>1)
+    for l = 2:L+1
+        factors = B.factors[l]
+        permutations = B.permutations[l]
+        indsout = B.indices[l]
+        indsin = B.indices[l-1]
+        ctr = 0
+        for i = 1:ii
+            shft = 2jj*div(ctr,2jj)
+            for j = 1:jj
+                A_mul_B!(temp2, factors[j+ctr], permutations[j+ctr], temp1, indsout[j+ctr], indsin[2j+shft-1])
+            end
+            ctr += jj
+        end
+        temp1, temp2 = temp2, fill!(temp1, zero(T))
+        ii <<= 1
+        jj >>= 1
+    end
+
+    columns = B.columns
+    inds = B.indices[L+1]
+    mu = 0
+    for i = 1:tL
+        ml = mu+1
+        mu += size(columns[i], 1)
+        A_mul_B!(u, columns[i], temp1, ml, inds[i])
+    end
+
+    u
+end
+
+function A_mul_B_col_J!{T}(u::Matrix{T}, B::Butterfly{T}, b::Matrix{T}, J::Int)
+    L = length(B.factors) - 1
+    tL = 2^L
+
+    M, N = size(b)
+
+    COLSHIFT = M*(J-1)
+
+    temp1 = B.temp1
+    temp2 = B.temp2
+    fill!(temp1, zero(T))
+    fill!(temp2, zero(T))
+
+    factors = B.factors[1]
+    permutations = B.permutations[1]
+    inds = B.indices[1]
+    nu = 0
+    for j = 1:tL
+        nl = nu+1
+        nu += size(factors[j], 2)
+        A_mul_B!(temp1, factors[j], permutations[j], b, inds[j], nl+COLSHIFT)
+    end
+
+    ii, jj = 2, (tL>>1)
+    for l = 2:L+1
+        factors = B.factors[l]
+        permutations = B.permutations[l]
+        indsout = B.indices[l]
+        indsin = B.indices[l-1]
+        ctr = 0
+        for i = 1:ii
+            shft = 2jj*div(ctr,2jj)
+            for j = 1:jj
+                A_mul_B!(temp2, factors[j+ctr], permutations[j+ctr], temp1, indsout[j+ctr], indsin[2j+shft-1])
+            end
+            ctr += jj
+        end
+        temp1, temp2 = temp2, fill!(temp1, zero(T))
+        ii <<= 1
+        jj >>= 1
+    end
+
+    columns = B.columns
+    inds = B.indices[L+1]
+    mu = 0
+    for i = 1:tL
+        ml = mu+1
+        mu += size(columns[i], 1)
+        A_mul_B!(u, columns[i], temp1, ml+COLSHIFT, inds[i])
+    end
+
+    u
+end
+
+function sumkmax(indices::Vector{Vector{Int64}})
+    ret = 0
+    @inbounds for j = 1:length(indices)
+        ret = max(ret, indices[j][end])
+    end
+    ret
+end
+
+
+function allranks(B::Butterfly)
+    L = length(B.factors)-1
+    tL = 2^L
+    ret = zeros(Int64, tL, L+1)
+    @inbounds for l = 1:L+1
+        for j = 1:tL
+            ret[j,l] = size(B.factors[l][j], 1)
+        end
+    end
+
+    ret
+end

--- a/src/SphericalHarmonics/Butterfly.jl
+++ b/src/SphericalHarmonics/Butterfly.jl
@@ -166,7 +166,7 @@ function A_mul_B!{T}(y::AbstractVecOrMat{T}, A::IDPackedV{T}, P::ColumnPermutati
     k, n = size(A)
     At_mul_B!(P, x, jstart)
     copy!(y, istart, x, jstart, k)
-    HierarchicalMatrices.A_mul_B!(y, A.T, x, istart, jstart+k)
+    A_mul_B!(y, A.T, x, istart, jstart+k)
     A_mul_B!(P, x, jstart)
     y
 end
@@ -176,7 +176,7 @@ for f! in (:At_mul_B!, :Ac_mul_B!)
         function $f!{T}(y::AbstractVecOrMat{T}, A::IDPackedV{T}, P::ColumnPermutation, x::AbstractVecOrMat{T}, istart::Int, jstart::Int)
             k, n = size(A)
             copy!(y, istart, x, jstart, k)
-            HierarchicalMatrices.$f!(y, A.T, x, istart+k, jstart)
+            $f!(y, A.T, x, istart+k, jstart)
             A_mul_B!(P, y, istart)
             y
         end
@@ -185,9 +185,9 @@ end
 
 ### A_mul_B!, At_mul_B!, and  Ac_mul_B! for a Butterfly factorization.
 
-A_mul_B!{T}(u::Vector{T}, B::Butterfly{T}, b::Vector{T}) = A_mul_B_col_J!(u, B, b, 1)
-At_mul_B!{T}(u::Vector{T}, B::Butterfly{T}, b::Vector{T}) = At_mul_B_col_J!(u, B, b, 1)
-Ac_mul_B!{T}(u::Vector{T}, B::Butterfly{T}, b::Vector{T}) = Ac_mul_B_col_J!(u, B, b, 1)
+Base.A_mul_B!{T}(u::Vector{T}, B::Butterfly{T}, b::Vector{T}) = A_mul_B_col_J!(u, B, b, 1)
+Base.At_mul_B!{T}(u::Vector{T}, B::Butterfly{T}, b::Vector{T}) = At_mul_B_col_J!(u, B, b, 1)
+Base.Ac_mul_B!{T}(u::Vector{T}, B::Butterfly{T}, b::Vector{T}) = Ac_mul_B_col_J!(u, B, b, 1)
 
 function A_mul_B_col_J!{T}(u::VecOrMat{T}, B::Butterfly{T}, b::VecOrMat{T}, J::Int)
     L = length(B.factors) - 1
@@ -237,7 +237,7 @@ function A_mul_B_col_J!{T}(u::VecOrMat{T}, B::Butterfly{T}, b::VecOrMat{T}, J::I
     for i = 1:tL
         ml = mu+1
         mu += size(columns[i], 1)
-        HierarchicalMatrices.A_mul_B!(u, columns[i], temp1, ml+COLSHIFT, inds[i])
+        A_mul_B!(u, columns[i], temp1, ml+COLSHIFT, inds[i])
     end
 
     u
@@ -267,7 +267,7 @@ for f! in (:At_mul_B!,:Ac_mul_B!)
             for i = 1:tL
                 ml = mu+1
                 mu += size(columns[i], 1)
-                HierarchicalMatrices.$f!(temp1, columns[i], b, inds[i], ml+COLSHIFT)
+                $f!(temp1, columns[i], b, inds[i], ml+COLSHIFT)
             end
 
             ii, jj = tL, 1

--- a/src/SphericalHarmonics/SphericalHarmonics.jl
+++ b/src/SphericalHarmonics/SphericalHarmonics.jl
@@ -1,3 +1,16 @@
+function zero_spurious_modes!(A::AbstractMatrix)
+    M, N = size(A)
+    n = N÷2
+    @inbounds for j = 1:n
+        @simd for i = M-j+1:M
+            A[i,2j] = 0
+            A[i,2j+1] = 0
+        end
+    end
+    A
+end
+
 include("slowplan.jl")
 include("Butterfly.jl")
 include("fastplan.jl")
+include("thinplan.jl")

--- a/src/SphericalHarmonics/SphericalHarmonics.jl
+++ b/src/SphericalHarmonics/SphericalHarmonics.jl
@@ -36,3 +36,76 @@ end
 
 sph2fourier(A::AbstractMatrix; opts...) = plan_sph2fourier(A; opts...)*A
 fourier2sph(A::AbstractMatrix; opts...) = plan_sph2fourier(A; opts...)\A
+
+doc"""
+Computes the bivariate Fourier series given by the spherical harmonic expansion:
+
+```math
+{\rm SHT} : \sum_{\ell=0}^n\sum_{m=-\ell}^{\ell} f_{\ell}^m Y_{\ell}^m(\theta,\varphi) \to \sum_{\ell=0}^n\sum_{m=-n}^{n} g_{\ell}^m \frac{e^{{\rm i} m \varphi}}{\sqrt{2\pi}} \left\{\begin{array}{c}\cos\ell\theta\\ \sin(\ell+1)\theta\end{array}\right\},
+```
+
+where the cosines are used when ``m`` is even and the sines are used when ``m`` is odd. The spherical harmonic expansion coefficients are organized as follows:
+
+```math
+F = \begin{pmatrix}
+f_0^0 & f_1^{-1} & f_1^1 & f_2^{-2} & f_2^2 & \cdots & f_n^{-n} & f_n^n\\
+f_1^0 & f_2^{-1} & f_2^1 & f_3^{-2} & f_3^2 & \cdots & 0 & 0\\
+\vdots & \vdots & \vdots &  \vdots &  \vdots & \ddots & \vdots & \vdots\\
+f_{n-2}^0 & f_{n-1}^{-1} & f_{n-1}^1 & f_n^{-2} & f_n^2 &  & \vdots & \vdots\\
+f_{n-1}^0 & f_n^{-1} & f_n^1 & 0 & 0 & \cdots & 0 & 0\\
+f_n^0 & 0 & 0 & 0 & 0 & \cdots & 0 & 0\\
+\end{pmatrix},
+```
+
+and the Fourier coefficients are organized similarly:
+
+```math
+G = \begin{pmatrix}
+g_0^0 & g_0^{-1} & g_0^1 & \cdots & g_0^{-n} & g_0^n\\
+g_1^0 & g_1^{-1} & g_1^1 & \cdots & g_1^{-n} & g_1^n\\
+\vdots & \vdots & \vdots & \ddots & \vdots & \vdots\\
+g_{n-1}^0 & g_{n-1}^{-1} & g_{n-1}^1& \cdots & g_{n-1}^{-n} & g_{n-1}^n\\
+g_n^0 & 0 & 0 & \cdots & g_n^{-n} & g_n^n\\
+\end{pmatrix}.
+```
+"""
+sph2fourier(::AbstractMatrix; opts...)
+
+doc"""
+Computes the spherical harmonic expansion given by the bivariate Fourier series:
+
+```math
+{\rm iSHT} : \sum_{\ell=0}^n\sum_{m=-n}^{n} g_{\ell}^m \frac{e^{{\rm i} m \varphi}}{\sqrt{2\pi}} \left\{\begin{array}{c}\cos\ell\theta\\ \sin(\ell+1)\theta\end{array}\right\} \to \sum_{\ell=0}^n\sum_{m=-\ell}^{\ell} f_{\ell}^m Y_{\ell}^m(\theta,\varphi),
+```
+
+where the cosines are used when ``m`` is even and the sines are used when ``m`` is odd. The spherical harmonic expansion coefficients are organized as follows:
+
+```math
+F = \begin{pmatrix}
+f_0^0 & f_1^{-1} & f_1^1 & f_2^{-2} & f_2^2 & \cdots & f_n^{-n} & f_n^n\\
+f_1^0 & f_2^{-1} & f_2^1 & f_3^{-2} & f_3^2 & \cdots & 0 & 0\\
+\vdots & \vdots & \vdots &  \vdots &  \vdots & \ddots & \vdots & \vdots\\
+f_{n-2}^0 & f_{n-1}^{-1} & f_{n-1}^1 & f_n^{-2} & f_n^2 &  & \vdots & \vdots\\
+f_{n-1}^0 & f_n^{-1} & f_n^1 & 0 & 0 & \cdots & 0 & 0\\
+f_n^0 & 0 & 0 & 0 & 0 & \cdots & 0 & 0\\
+\end{pmatrix},
+```
+
+and the Fourier coefficients are organized similarly:
+
+```math
+G = \begin{pmatrix}
+g_0^0 & g_0^{-1} & g_0^1 & \cdots & g_0^{-n} & g_0^n\\
+g_1^0 & g_1^{-1} & g_1^1 & \cdots & g_1^{-n} & g_1^n\\
+\vdots & \vdots & \vdots & \ddots & \vdots & \vdots\\
+g_{n-1}^0 & g_{n-1}^{-1} & g_{n-1}^1& \cdots & g_{n-1}^{-n} & g_{n-1}^n\\
+g_n^0 & 0 & 0 & \cdots & g_n^{-n} & g_n^n\\
+\end{pmatrix}.
+```
+"""
+fourier2sph(::AbstractMatrix; opts...)
+
+doc"""
+Pre-computes the spherical harmonic transform.
+"""
+plan_sph2fourier(::AbstractMatrix; opts...)

--- a/src/SphericalHarmonics/SphericalHarmonics.jl
+++ b/src/SphericalHarmonics/SphericalHarmonics.jl
@@ -1,0 +1,3 @@
+include("slowplan.jl")
+include("Butterfly.jl")
+include("fastplan.jl")

--- a/src/SphericalHarmonics/SphericalHarmonics.jl
+++ b/src/SphericalHarmonics/SphericalHarmonics.jl
@@ -10,7 +10,29 @@ function zero_spurious_modes!(A::AbstractMatrix)
     A
 end
 
+@compat abstract type SphericalHarmonicPlan{T} end
+
+function *(P::SphericalHarmonicPlan, X::AbstractMatrix)
+    A_mul_B!(zero(X), P, X)
+end
+
+function \(P::SphericalHarmonicPlan, X::AbstractMatrix)
+    At_mul_B!(zero(X), P, X)
+end
+
 include("slowplan.jl")
 include("Butterfly.jl")
 include("fastplan.jl")
 include("thinplan.jl")
+
+function plan_sph2fourier(A::AbstractMatrix; opts...)
+    M, N = size(A)
+    if M ≤ 1022
+        SlowSphericalHarmonicPlan(A)
+    else
+        ThinSphericalHarmonicPlan(A; opts...)
+    end
+end
+
+sph2fourier(A::AbstractMatrix; opts...) = plan_sph2fourier(A; opts...)*A
+fourier2sph(A::AbstractMatrix; opts...) = plan_sph2fourier(A; opts...)\A

--- a/src/SphericalHarmonics/SphericalHarmonics.jl
+++ b/src/SphericalHarmonics/SphericalHarmonics.jl
@@ -1,15 +1,3 @@
-function zero_spurious_modes!(A::AbstractMatrix)
-    M, N = size(A)
-    n = N÷2
-    @inbounds for j = 1:n
-        @simd for i = M-j+1:M
-            A[i,2j] = 0
-            A[i,2j+1] = 0
-        end
-    end
-    A
-end
-
 @compat abstract type SphericalHarmonicPlan{T} end
 
 function *(P::SphericalHarmonicPlan, X::AbstractMatrix)
@@ -20,6 +8,7 @@ function \(P::SphericalHarmonicPlan, X::AbstractMatrix)
     At_mul_B!(zero(X), P, X)
 end
 
+include("sphfunctions.jl")
 include("slowplan.jl")
 include("Butterfly.jl")
 include("fastplan.jl")

--- a/src/SphericalHarmonics/fastplan.jl
+++ b/src/SphericalHarmonics/fastplan.jl
@@ -8,7 +8,7 @@ immutable FastSphericalHarmonicPlan{T}
     B::Matrix{T}
 end
 
-function FastSphericalHarmonicPlan{T}(A::Matrix{T}, L::Int)
+function FastSphericalHarmonicPlan{T}(A::Matrix{T}, L::Int; opts...)
     M, N = size(A)
     @assert ispow2(M)
     @assert N == 2M-1
@@ -25,18 +25,18 @@ function FastSphericalHarmonicPlan{T}(A::Matrix{T}, L::Int)
     BF = Vector{Butterfly{T}}(n-2)
     for j = 1:2:n-2
         A_mul_B!(Ce, RP.layers[j])
-        BF[j] = orthogonalButterfly(Ce, L)
+        BF[j] = orthogonalButterfly(Ce, L; opts...)
         println("Layer: ",j)
     end
     for j = 2:2:n-2
         A_mul_B!(Co, RP.layers[j])
-        BF[j] = orthogonalButterfly(Co, L)
+        BF[j] = orthogonalButterfly(Co, L; opts...)
         println("Layer: ",j)
     end
     FastSphericalHarmonicPlan(RP, BF, p1, p2, p1inv, p2inv, B)
 end
 
-FastSphericalHarmonicPlan(A::Matrix) = FastSphericalHarmonicPlan(A, round(Int, log2(size(A, 1)+1)-6))
+FastSphericalHarmonicPlan(A::Matrix; opts...) = FastSphericalHarmonicPlan(A, round(Int, log2(size(A, 1)+1)-6); opts...)
 
 function A_mul_B!(Y::Matrix, FP::FastSphericalHarmonicPlan, X::Matrix)
     RP, BF, p1, p2, B = FP.RP, FP.BF, FP.p1, FP.p2, FP.B

--- a/src/SphericalHarmonics/fastplan.jl
+++ b/src/SphericalHarmonics/fastplan.jl
@@ -1,0 +1,48 @@
+immutable FastSphericalHarmonicPlan{T}
+    RP::RotationPlan{T}
+    BF::Vector{Butterfly{T}}
+    p1::NormalizedLegendreToChebyshevPlan{T}
+    p2::NormalizedLegendre1ToChebyshev2Plan{T}
+    p1inv::ChebyshevToNormalizedLegendrePlan{T}
+    p2inv::Chebyshev2ToNormalizedLegendre1Plan{T}
+    B::Matrix{T}
+end
+
+function FastSphericalHarmonicPlan{T}(A::Matrix{T}, L::Int)
+    m, n = size(A)
+    RP = RotationPlan(T, n-1)
+    a1 = A[:,1]
+    p1 = plan_normleg2cheb(a1)
+    p2 = plan_normleg12cheb2(a1)
+    p1inv = plan_cheb2normleg(a1)
+    p2inv = plan_cheb22normleg1(a1)
+    B = zeros(A)
+    Ce = eye(A)
+    Co = eye(A)
+    BF = Vector{Butterfly{T}}(n-2)
+    for j = 1:2:n-2
+        A_mul_B!(Ce, RP.layers[j])
+        BF[j] = Butterfly(Ce, L)
+        println("Level: ",j)
+    end
+    for j = 2:2:n-2
+        A_mul_B!(Co, RP.layers[j])
+        BF[j] = Butterfly(Co, L)
+        println("Level: ",j)
+    end
+    FastSphericalHarmonicPlan(RP, BF, p1, p2, p1inv, p2inv, B)
+end
+
+
+function A_mul_B!(Y::Matrix, FP::FastSphericalHarmonicPlan, X::Matrix)
+    RP, BF, p1, p2, B = FP.RP, FP.BF, FP.p1, FP.p2, FP.B
+    fill!(B, zero(eltype(B)))
+    copy!(B, 1, X, 1, 2size(X, 1))
+    for j = 3:size(X, 2)
+        A_mul_B_col_J!(B, BF[j-2], X, j)
+    end
+    A_mul_B_odd_cols!!(Y, p1, B)
+    A_mul_B_even_cols!!(Y, p2, B)
+end
+
+allranks(FP::FastSphericalHarmonicPlan) = mapreduce(allranks,vcat,FP.BF)

--- a/src/SphericalHarmonics/fastplan.jl
+++ b/src/SphericalHarmonics/fastplan.jl
@@ -23,13 +23,13 @@ function FastSphericalHarmonicPlan{T}(A::Matrix{T}, L::Int)
     BF = Vector{Butterfly{T}}(n-2)
     for j = 1:2:n-2
         A_mul_B!(Ce, RP.layers[j])
-        BF[j] = Butterfly(Ce, L)
-        println("Level: ",j)
+        BF[j] = orthogonalButterfly(Ce, L)
+        #println("Level: ",j)
     end
     for j = 2:2:n-2
         A_mul_B!(Co, RP.layers[j])
-        BF[j] = Butterfly(Co, L)
-        println("Level: ",j)
+        BF[j] = orthogonalButterfly(Co, L)
+        #println("Level: ",j)
     end
     FastSphericalHarmonicPlan(RP, BF, p1, p2, p1inv, p2inv, B)
 end

--- a/src/SphericalHarmonics/fastplan.jl
+++ b/src/SphericalHarmonics/fastplan.jl
@@ -10,6 +10,8 @@ end
 
 function FastSphericalHarmonicPlan{T}(A::Matrix{T}, L::Int)
     M, N = size(A)
+    @assert ispow2(M)
+    @assert N == 2M-1
     n = (N+1)÷2
     RP = RotationPlan(T, n-1)
     a1 = A[:,1]
@@ -24,16 +26,17 @@ function FastSphericalHarmonicPlan{T}(A::Matrix{T}, L::Int)
     for j = 1:2:n-2
         A_mul_B!(Ce, RP.layers[j])
         BF[j] = orthogonalButterfly(Ce, L)
-        #println("Level: ",j)
+        println("Layer: ",j)
     end
     for j = 2:2:n-2
         A_mul_B!(Co, RP.layers[j])
         BF[j] = orthogonalButterfly(Co, L)
-        #println("Level: ",j)
+        println("Layer: ",j)
     end
     FastSphericalHarmonicPlan(RP, BF, p1, p2, p1inv, p2inv, B)
 end
 
+FastSphericalHarmonicPlan(A::Matrix) = FastSphericalHarmonicPlan(A, round(Int, log2(size(A, 1)+1)-6))
 
 function A_mul_B!(Y::Matrix, FP::FastSphericalHarmonicPlan, X::Matrix)
     RP, BF, p1, p2, B = FP.RP, FP.BF, FP.p1, FP.p2, FP.B
@@ -76,7 +79,7 @@ function At_mul_B!(Y::Matrix, FP::FastSphericalHarmonicPlan, X::Matrix)
         At_mul_B_col_J!(Y, BF[J-1], B, 2J)
         At_mul_B_col_J!(Y, BF[J-1], B, 2J+1)
     end
-    Y
+    zero_spurious_modes!(Y)
 end
 
 Ac_mul_B!(Y::Matrix, FP::FastSphericalHarmonicPlan, X::Matrix) = At_mul_B!(Y, FP, X)

--- a/src/SphericalHarmonics/fastplan.jl
+++ b/src/SphericalHarmonics/fastplan.jl
@@ -22,7 +22,7 @@ function FastSphericalHarmonicPlan{T}(A::Matrix{T}, L::Int; opts...)
     Ce = eye(T, M)
     Co = eye(T, M)
     BF = Vector{Butterfly{T}}(n-2)
-    P = Progress(n-2, 0.1, "Pre-computing fast plan...", 50)
+    P = Progress(n-2, 0.1, "Pre-computing...", 43)
     for j = 1:2:n-2
         A_mul_B!(Ce, RP.layers[j])
         BF[j] = Butterfly(Ce, L; isorthogonal = true, opts...)

--- a/src/SphericalHarmonics/fastplan.jl
+++ b/src/SphericalHarmonics/fastplan.jl
@@ -38,7 +38,7 @@ end
 
 FastSphericalHarmonicPlan(A::Matrix; opts...) = FastSphericalHarmonicPlan(A, round(Int, log2(size(A, 1)+1)-6); opts...)
 
-function A_mul_B!(Y::Matrix, FP::FastSphericalHarmonicPlan, X::Matrix)
+function Base.A_mul_B!(Y::Matrix, FP::FastSphericalHarmonicPlan, X::Matrix)
     RP, BF, p1, p2, B = FP.RP, FP.BF, FP.p1, FP.p2, FP.B
     fill!(B, zero(eltype(B)))
     M, N = size(X)
@@ -60,7 +60,7 @@ function A_mul_B!(Y::Matrix, FP::FastSphericalHarmonicPlan, X::Matrix)
     Y
 end
 
-function At_mul_B!(Y::Matrix, FP::FastSphericalHarmonicPlan, X::Matrix)
+function Base.At_mul_B!(Y::Matrix, FP::FastSphericalHarmonicPlan, X::Matrix)
     RP, BF, p1inv, p2inv, B = FP.RP, FP.BF, FP.p1inv, FP.p2inv, FP.B
     copy!(B, X)
     M, N = size(X)
@@ -82,6 +82,6 @@ function At_mul_B!(Y::Matrix, FP::FastSphericalHarmonicPlan, X::Matrix)
     zero_spurious_modes!(Y)
 end
 
-Ac_mul_B!(Y::Matrix, FP::FastSphericalHarmonicPlan, X::Matrix) = At_mul_B!(Y, FP, X)
+Base.Ac_mul_B!(Y::Matrix, FP::FastSphericalHarmonicPlan, X::Matrix) = At_mul_B!(Y, FP, X)
 
 allranks(FP::FastSphericalHarmonicPlan) = mapreduce(allranks,vcat,FP.BF)

--- a/src/SphericalHarmonics/fastplan.jl
+++ b/src/SphericalHarmonics/fastplan.jl
@@ -9,7 +9,8 @@ immutable FastSphericalHarmonicPlan{T}
 end
 
 function FastSphericalHarmonicPlan{T}(A::Matrix{T}, L::Int)
-    m, n = size(A)
+    M, N = size(A)
+    n = (N+1)÷2
     RP = RotationPlan(T, n-1)
     a1 = A[:,1]
     p1 = plan_normleg2cheb(a1)
@@ -17,8 +18,8 @@ function FastSphericalHarmonicPlan{T}(A::Matrix{T}, L::Int)
     p1inv = plan_cheb2normleg(a1)
     p2inv = plan_cheb22normleg1(a1)
     B = zeros(A)
-    Ce = eye(A)
-    Co = eye(A)
+    Ce = eye(T, M)
+    Co = eye(T, M)
     BF = Vector{Butterfly{T}}(n-2)
     for j = 1:2:n-2
         A_mul_B!(Ce, RP.layers[j])
@@ -37,12 +38,47 @@ end
 function A_mul_B!(Y::Matrix, FP::FastSphericalHarmonicPlan, X::Matrix)
     RP, BF, p1, p2, B = FP.RP, FP.BF, FP.p1, FP.p2, FP.B
     fill!(B, zero(eltype(B)))
-    copy!(B, 1, X, 1, 2size(X, 1))
-    for j = 3:size(X, 2)
-        A_mul_B_col_J!(B, BF[j-2], X, j)
+    M, N = size(X)
+    copy!(B, 1, X, 1, 3M)
+    for J = 2:N÷2
+        A_mul_B_col_J!(B, BF[J-1], X, 2J)
+        A_mul_B_col_J!(B, BF[J-1], X, 2J+1)
     end
-    A_mul_B_odd_cols!!(Y, p1, B)
-    A_mul_B_even_cols!!(Y, p2, B)
+
+    A_mul_B_col_J!!(Y, p1, B, 1)
+    for J = 2:4:N
+        A_mul_B_col_J!!(Y, p2, B, J)
+        A_mul_B_col_J!!(Y, p2, B, J+1)
+    end
+    for J = 4:4:N
+        A_mul_B_col_J!!(Y, p1, B, J)
+        A_mul_B_col_J!!(Y, p1, B, J+1)
+    end
+    Y
 end
+
+function At_mul_B!(Y::Matrix, FP::FastSphericalHarmonicPlan, X::Matrix)
+    RP, BF, p1inv, p2inv, B = FP.RP, FP.BF, FP.p1inv, FP.p2inv, FP.B
+    copy!(B, X)
+    M, N = size(X)
+    A_mul_B_col_J!!(Y, p1inv, B, 1)
+    for J = 2:4:N
+        A_mul_B_col_J!!(Y, p2inv, B, J)
+        A_mul_B_col_J!!(Y, p2inv, B, J+1)
+    end
+    for J = 4:4:N
+        A_mul_B_col_J!!(Y, p1inv, B, J)
+        A_mul_B_col_J!!(Y, p1inv, B, J+1)
+    end
+
+    copy!(B, Y)
+    for J = 2:N÷2
+        At_mul_B_col_J!(Y, BF[J-1], B, 2J)
+        At_mul_B_col_J!(Y, BF[J-1], B, 2J+1)
+    end
+    Y
+end
+
+Ac_mul_B!(Y::Matrix, FP::FastSphericalHarmonicPlan, X::Matrix) = At_mul_B!(Y, FP, X)
 
 allranks(FP::FastSphericalHarmonicPlan) = mapreduce(allranks,vcat,FP.BF)

--- a/src/SphericalHarmonics/fastplan.jl
+++ b/src/SphericalHarmonics/fastplan.jl
@@ -23,15 +23,16 @@ function FastSphericalHarmonicPlan{T}(A::Matrix{T}, L::Int; opts...)
     Ce = eye(T, M)
     Co = eye(T, M)
     BF = Vector{Butterfly{T}}(n-2)
+    P = Progress(n-2, 0.1, "Pre-computing fast plan...", 50)
     for j = 1:2:n-2
         A_mul_B!(Ce, RP.layers[j])
-        BF[j] = orthogonalButterfly(Ce, L; opts...)
-        println("Layer: ",j)
+        BF[j] = Butterfly(Ce, L; isorthogonal = true, opts...)
+        next!(P)
     end
     for j = 2:2:n-2
         A_mul_B!(Co, RP.layers[j])
-        BF[j] = orthogonalButterfly(Co, L; opts...)
-        println("Layer: ",j)
+        BF[j] = Butterfly(Co, L; isorthogonal = true, opts...)
+        next!(P)
     end
     FastSphericalHarmonicPlan(RP, BF, p1, p2, p1inv, p2inv, B)
 end

--- a/src/SphericalHarmonics/fastplan.jl
+++ b/src/SphericalHarmonics/fastplan.jl
@@ -1,4 +1,4 @@
-immutable FastSphericalHarmonicPlan{T}
+immutable FastSphericalHarmonicPlan{T} <: SphericalHarmonicPlan{T}
     RP::RotationPlan{T}
     BF::Vector{Butterfly{T}}
     p1::NormalizedLegendreToChebyshevPlan{T}
@@ -14,11 +14,10 @@ function FastSphericalHarmonicPlan{T}(A::Matrix{T}, L::Int; opts...)
     @assert N == 2M-1
     n = (N+1)÷2
     RP = RotationPlan(T, n-1)
-    a1 = A[:,1]
-    p1 = plan_normleg2cheb(a1)
-    p2 = plan_normleg12cheb2(a1)
-    p1inv = plan_cheb2normleg(a1)
-    p2inv = plan_cheb22normleg1(a1)
+    p1 = plan_normleg2cheb(A)
+    p2 = plan_normleg12cheb2(A)
+    p1inv = plan_cheb2normleg(A)
+    p2inv = plan_cheb22normleg1(A)
     B = zeros(A)
     Ce = eye(T, M)
     Co = eye(T, M)

--- a/src/SphericalHarmonics/slowplan.jl
+++ b/src/SphericalHarmonics/slowplan.jl
@@ -124,7 +124,7 @@ end
 Ac_mul_B!(P::RotationPlan, A::AbstractMatrix) = At_mul_B!(P, A)
 
 
-immutable SlowSphericalHarmonicPlan{T}
+immutable SlowSphericalHarmonicPlan{T} <: SphericalHarmonicPlan{T}
     RP::RotationPlan{T}
     p1::NormalizedLegendreToChebyshevPlan{T}
     p2::NormalizedLegendre1ToChebyshev2Plan{T}
@@ -137,11 +137,10 @@ function SlowSphericalHarmonicPlan{T}(A::Matrix{T})
     M, N = size(A)
     n = (N+1)÷2
     RP = RotationPlan(T, n-1)
-    a1 = A[:,1]
-    p1 = plan_normleg2cheb(a1)
-    p2 = plan_normleg12cheb2(a1)
-    p1inv = plan_cheb2normleg(a1)
-    p2inv = plan_cheb22normleg1(a1)
+    p1 = plan_normleg2cheb(A)
+    p2 = plan_normleg12cheb2(A)
+    p1inv = plan_cheb2normleg(A)
+    p2inv = plan_cheb22normleg1(A)
     B = zeros(A)
     SlowSphericalHarmonicPlan(RP, p1, p2, p1inv, p2inv, B)
 end

--- a/src/SphericalHarmonics/slowplan.jl
+++ b/src/SphericalHarmonics/slowplan.jl
@@ -20,8 +20,8 @@ function A_mul_B!(A::AbstractMatrix, G::Givens)
     end
     @inbounds @simd for i = 1:m
         a1, a2 = A[i,G.i1], A[i,G.i2]
-        A[i,G.i1] =       G.c *a1 + G.s*a2
-        A[i,G.i2] = -conj(G.s)*a1 + G.c*a2
+        A[i,G.i1] = G.c*a1 - conj(G.s)*a2
+        A[i,G.i2] = G.s*a1 +       G.c*a2
     end
     return A
 end
@@ -33,8 +33,8 @@ function A_mul_B!{T<:Real}(A::AbstractMatrix, G::Givens{T})
     end
     @inbounds @simd for i = 1:m
         a1, a2 = A[i,G.i1], A[i,G.i2]
-        A[i,G.i1] =  G.c*a1 + G.s*a2
-        A[i,G.i2] = -G.s*a1 + G.c*a2
+        A[i,G.i1] = G.c*a1 - G.s*a2
+        A[i,G.i2] = G.s*a1 + G.c*a2
     end
     return A
 end
@@ -85,7 +85,6 @@ end
 
 function A_mul_B!(P::RotationPlan, A::AbstractMatrix)
     n = length(P.layers)+1
-
     @inbounds for m = n-2:-1:0
         layer = P.layers[m+1]
         for ℓ = m+2:2:n
@@ -102,7 +101,6 @@ end
 
 function At_mul_B!(P::RotationPlan, A::AbstractMatrix)
     n = length(P.layers)+1
-
     @inbounds for m = 0:n-2
         layer = P.layers[m+1]
         for ℓ = m+2:2:n

--- a/src/SphericalHarmonics/slowplan.jl
+++ b/src/SphericalHarmonics/slowplan.jl
@@ -1,5 +1,7 @@
 import Base.LinAlg: Givens, AbstractRotation
 
+### These three A_mul_B! should be in Base, but for the time being they do not add methods to Base.A_mul_B!; they add methods to the internal A_mul_B!.
+
 function A_mul_B!{T<:Real}(G::Givens{T}, A::AbstractVecOrMat)
     m, n = size(A, 1), size(A, 2)
     if G.i2 > m
@@ -56,14 +58,14 @@ end
 @inline length(P::Pnmp2toPlm) = length(P.rotations)
 @inline getindex(P::Pnmp2toPlm, i::Int) = P.rotations[i]
 
-function A_mul_B!(C::Pnmp2toPlm,A::AbstractVecOrMat)
+function Base.A_mul_B!(C::Pnmp2toPlm,A::AbstractVecOrMat)
     @inbounds for i = 1:length(C)
         A_mul_B!(C.rotations[i], A)
     end
     A
 end
 
-function A_mul_B!(A::AbstractMatrix, C::Pnmp2toPlm)
+function Base.A_mul_B!(A::AbstractMatrix, C::Pnmp2toPlm)
     @inbounds for i = length(C):-1:1
         A_mul_B!(A, C.rotations[i])
     end
@@ -83,7 +85,7 @@ function RotationPlan{T}(::Type{T}, n::Int)
     RotationPlan(layers)
 end
 
-function A_mul_B!(P::RotationPlan, A::AbstractMatrix)
+function Base.A_mul_B!(P::RotationPlan, A::AbstractMatrix)
     M, N = size(A)
     @inbounds for m = N÷2-2:-1:0
         layer = P.layers[m+1]
@@ -102,7 +104,7 @@ function A_mul_B!(P::RotationPlan, A::AbstractMatrix)
     A
 end
 
-function At_mul_B!(P::RotationPlan, A::AbstractMatrix)
+function Base.At_mul_B!(P::RotationPlan, A::AbstractMatrix)
     M, N = size(A)
     @inbounds for m = 0:N÷2-2
         layer = P.layers[m+1]
@@ -121,7 +123,7 @@ function At_mul_B!(P::RotationPlan, A::AbstractMatrix)
     A
 end
 
-Ac_mul_B!(P::RotationPlan, A::AbstractMatrix) = At_mul_B!(P, A)
+Base.Ac_mul_B!(P::RotationPlan, A::AbstractMatrix) = At_mul_B!(P, A)
 
 
 immutable SlowSphericalHarmonicPlan{T} <: SphericalHarmonicPlan{T}
@@ -145,7 +147,7 @@ function SlowSphericalHarmonicPlan{T}(A::Matrix{T})
     SlowSphericalHarmonicPlan(RP, p1, p2, p1inv, p2inv, B)
 end
 
-function A_mul_B!(Y::Matrix, SP::SlowSphericalHarmonicPlan, X::Matrix)
+function Base.A_mul_B!(Y::Matrix, SP::SlowSphericalHarmonicPlan, X::Matrix)
     RP, p1, p2, B = SP.RP, SP.p1, SP.p2, SP.B
     copy!(B, X)
     A_mul_B!(RP, B)
@@ -162,7 +164,7 @@ function A_mul_B!(Y::Matrix, SP::SlowSphericalHarmonicPlan, X::Matrix)
     Y
 end
 
-function At_mul_B!(Y::Matrix, SP::SlowSphericalHarmonicPlan, X::Matrix)
+function Base.At_mul_B!(Y::Matrix, SP::SlowSphericalHarmonicPlan, X::Matrix)
     RP, p1inv, p2inv, B = SP.RP, SP.p1inv, SP.p2inv, SP.B
     copy!(B, X)
     M, N = size(X)
@@ -178,4 +180,4 @@ function At_mul_B!(Y::Matrix, SP::SlowSphericalHarmonicPlan, X::Matrix)
     zero_spurious_modes!(At_mul_B!(RP, Y))
 end
 
-Ac_mul_B!(Y::Matrix, SP::SlowSphericalHarmonicPlan, X::Matrix) = At_mul_B!(Y, SP, X)
+Base.Ac_mul_B!(Y::Matrix, SP::SlowSphericalHarmonicPlan, X::Matrix) = At_mul_B!(Y, SP, X)

--- a/src/SphericalHarmonics/slowplan.jl
+++ b/src/SphericalHarmonics/slowplan.jl
@@ -1,0 +1,110 @@
+import Base.LinAlg: Givens, AbstractRotation
+
+immutable Pnmp2toPlm{T} <: AbstractRotation{T}
+    rotations::Vector{Givens{T}}
+end
+
+function Pnmp2toPlm{T}(::Type{T}, n::Int, m::Int)
+    G = Vector{Givens{T}}(n)
+    for ℓ = 1:n
+        c = sqrt((2ℓ+2m+3)/(ℓ+2m+3)*(2m+2)/(ℓ+2m+2))
+        s = sqrt((ℓ+1)/(ℓ+2m+3)*ℓ/(ℓ+2m+2))
+        G[n+1-ℓ] = Givens(ℓ, ℓ+2, c, s)
+    end
+    Pnmp2toPlm(G)
+end
+
+@inline length(P::Pnmp2toPlm) = length(P.rotations)
+@inline getindex(P::Pnmp2toPlm,i::Int) = P.rotations[i]
+
+function A_mul_B!(C::Pnmp2toPlm,A::AbstractVecOrMat)
+    for i = 1:length(C)
+        A_mul_B!(C.rotations[i], A)
+    end
+    A
+end
+
+
+immutable RotationPlan{T} <: AbstractRotation{T}
+    layers::Vector{Pnmp2toPlm{T}}
+end
+
+function RotationPlan{T}(::Type{T}, n::Int)
+    layers = Vector{Pnmp2toPlm{T}}(n-1)
+    for m = 0:n-2
+        layers[m+1] = Pnmp2toPlm(T, n-1-m, m)
+    end
+    RotationPlan(layers)
+end
+
+function A_mul_B!(P::RotationPlan, A::AbstractMatrix)
+    n = length(P.layers)+1
+
+    @inbounds for m = n-2:-1:0
+        layer = P.layers[m+1]
+        for ℓ = m+2:2:n
+            @simd for i = 1:length(layer)
+                G = layer[i]
+                a1, a2 = A[G.i1,ℓ+1], A[G.i2,ℓ+1]
+                A[G.i1,ℓ+1] = G.c*a1 + G.s*a2
+                A[G.i2,ℓ+1] = G.c*a2 - G.s*a1
+            end
+        end
+    end
+    A
+end
+
+function Ac_mul_B!(P::RotationPlan, A::AbstractMatrix)
+    n = length(P.layers)+1
+
+    @inbounds for m = 0:n-2
+        layer = P.layers[m+1]
+        for ℓ = m+2:2:n
+            @simd for i = length(layer):-1:1
+                G = layer[i]
+                a1, a2 = A[G.i1,ℓ+1], A[G.i2,ℓ+1]
+                A[G.i1,ℓ+1] = G.c*a1 - G.s*a2
+                A[G.i2,ℓ+1] = G.s*a1 + G.c*a2
+            end
+        end
+    end
+    A
+end
+
+
+immutable SlowSphericalHarmonicPlan{T}
+    RP::RotationPlan{T}
+    p1::NormalizedLegendreToChebyshevPlan{T}
+    p2::NormalizedLegendre1ToChebyshev2Plan{T}
+    p1inv::ChebyshevToNormalizedLegendrePlan{T}
+    p2inv::Chebyshev2ToNormalizedLegendre1Plan{T}
+    B::Matrix{T}
+end
+
+function SlowSphericalHarmonicPlan{T}(A::Matrix{T})
+    m, n = size(A)
+    RP = RotationPlan(T, n-1)
+    a1 = A[:,1]
+    p1 = plan_normleg2cheb(a1)
+    p2 = plan_normleg12cheb2(a1)
+    p1inv = plan_cheb2normleg(a1)
+    p2inv = plan_cheb22normleg1(a1)
+    B = zeros(A)
+    SlowSphericalHarmonicPlan(RP, p1, p2, p1inv, p2inv, B)
+end
+
+function A_mul_B!(Y::Matrix, SP::SlowSphericalHarmonicPlan, X::Matrix)
+    RP, p1, p2, B = SP.RP, SP.p1, SP.p2, SP.B
+    copy!(B, X)
+    A_mul_B!(RP, B)
+    A_mul_B_odd_cols!!(Y, p1, B)
+    A_mul_B_even_cols!!(Y, p2, B)
+end
+
+function Ac_mul_B!(Y::Matrix, SP::SlowSphericalHarmonicPlan, X::Matrix)
+    RP, p1inv, p2inv, B = SP.RP, SP.p1inv, SP.p2inv, SP.B
+    copy!(B, X)
+    A_mul_B_odd_cols!!(Y, p1inv, B)
+    A_mul_B_even_cols!!(Y, p2inv, B)
+    Ac_mul_B!(RP, Y)
+end

--- a/src/SphericalHarmonics/slowplan.jl
+++ b/src/SphericalHarmonics/slowplan.jl
@@ -176,7 +176,7 @@ function At_mul_B!(Y::Matrix, SP::SlowSphericalHarmonicPlan, X::Matrix)
         A_mul_B_col_J!!(Y, p1inv, B, J)
         A_mul_B_col_J!!(Y, p1inv, B, J+1)
     end
-    At_mul_B!(RP, Y)
+    zero_spurious_modes!(At_mul_B!(RP, Y))
 end
 
 Ac_mul_B!(Y::Matrix, SP::SlowSphericalHarmonicPlan, X::Matrix) = At_mul_B!(Y, SP, X)

--- a/src/SphericalHarmonics/thinplan.jl
+++ b/src/SphericalHarmonics/thinplan.jl
@@ -1,0 +1,185 @@
+const LAYERSKELETON = 64
+
+checklayer(j::Int) = j÷LAYERSKELETON == j/LAYERSKELETON
+
+immutable ThinSphericalHarmonicPlan{T}
+    RP::RotationPlan{T}
+    BF::Vector{Butterfly{T}}
+    p1::NormalizedLegendreToChebyshevPlan{T}
+    p2::NormalizedLegendre1ToChebyshev2Plan{T}
+    p1inv::ChebyshevToNormalizedLegendrePlan{T}
+    p2inv::Chebyshev2ToNormalizedLegendre1Plan{T}
+    B::Matrix{T}
+end
+
+function ThinSphericalHarmonicPlan{T}(A::Matrix{T}, L::Int)
+    M, N = size(A)
+    @assert ispow2(M)
+    @assert N == 2M-1
+    n = (N+1)÷2
+    RP = RotationPlan(T, n-1)
+    a1 = A[:,1]
+    p1 = plan_normleg2cheb(a1)
+    p2 = plan_normleg12cheb2(a1)
+    p1inv = plan_cheb2normleg(a1)
+    p2inv = plan_cheb22normleg1(a1)
+    B = zeros(A)
+    Ce = eye(T, M)
+    Co = eye(T, M)
+    BF = Vector{Butterfly{T}}(n-2)
+    for j = 1:2:n-2
+        A_mul_B!(Ce, RP.layers[j])
+        checklayer(j+1) && (BF[j] = orthogonalButterfly(Ce, L);println("Layer: ",j))
+    end
+    for j = 2:2:n-2
+        A_mul_B!(Co, RP.layers[j])
+        checklayer(j) && (BF[j] = orthogonalButterfly(Co, L);println("Layer: ",j))
+    end
+    ThinSphericalHarmonicPlan(RP, BF, p1, p2, p1inv, p2inv, B)
+end
+
+ThinSphericalHarmonicPlan(A::Matrix) = ThinSphericalHarmonicPlan(A, round(Int, log2(size(A, 1)+1)-6))
+
+function A_mul_B!(Y::Matrix, TP::ThinSphericalHarmonicPlan, X::Matrix)
+    RP, BF, p1, p2, B = TP.RP, TP.BF, TP.p1, TP.p2, TP.B
+    copy!(B, X)
+    M, N = size(X)
+
+    for j = 3:2:N÷2
+        if checklayer(j-1)
+            A_mul_B_col_J!(Y, BF[j-1], B, 2j)
+            A_mul_B_col_J!(Y, BF[j-1], B, 2j+1)
+        else
+            ℓ = round(Int, (j-1)÷LAYERSKELETON)*LAYERSKELETON
+            A_mul_B_col_J!(RP, B, 2j, ℓ+1, j-1)
+            A_mul_B_col_J!(RP, B, 2j+1, ℓ+1, j-1)
+            if ℓ > LAYERSKELETON-2
+                A_mul_B_col_J!(Y, BF[ℓ], B, 2j)
+                A_mul_B_col_J!(Y, BF[ℓ], B, 2j+1)
+            else
+                copy!(Y, 1+M*(2j-1), B, 1+M*(2j-1), 2M)
+            end
+        end
+    end
+
+    for j = 2:2:N÷2
+        if checklayer(j)
+            A_mul_B_col_J!(Y, BF[j-1], B, 2j)
+            A_mul_B_col_J!(Y, BF[j-1], B, 2j+1)
+        else
+            ℓ = round(Int, j÷LAYERSKELETON)*LAYERSKELETON
+            A_mul_B_col_J!(RP, B, 2j, ℓ, j-1)
+            A_mul_B_col_J!(RP, B, 2j+1, ℓ, j-1)
+            if ℓ > LAYERSKELETON-2
+                A_mul_B_col_J!(Y, BF[ℓ-1], B, 2j)
+                A_mul_B_col_J!(Y, BF[ℓ-1], B, 2j+1)
+            else
+                copy!(Y, 1+M*(2j-1), B, 1+M*(2j-1), 2M)
+            end
+        end
+    end
+
+    copy!(Y, 1, X, 1, 3M)
+    copy!(B, Y)
+    fill!(Y, zero(eltype(Y)))
+
+    A_mul_B_col_J!!(Y, p1, B, 1)
+    for J = 2:4:N
+        A_mul_B_col_J!!(Y, p2, B, J)
+        A_mul_B_col_J!!(Y, p2, B, J+1)
+    end
+    for J = 4:4:N
+        A_mul_B_col_J!!(Y, p1, B, J)
+        A_mul_B_col_J!!(Y, p1, B, J+1)
+    end
+    Y
+end
+
+
+function At_mul_B!(Y::Matrix, TP::ThinSphericalHarmonicPlan, X::Matrix)
+    RP, BF, p1inv, p2inv, B = TP.RP, TP.BF, TP.p1inv, TP.p2inv, TP.B
+    copy!(B, X)
+    M, N = size(X)
+    A_mul_B_col_J!!(Y, p1inv, B, 1)
+    for J = 2:4:N
+        A_mul_B_col_J!!(Y, p2inv, B, J)
+        A_mul_B_col_J!!(Y, p2inv, B, J+1)
+    end
+    for J = 4:4:N
+        A_mul_B_col_J!!(Y, p1inv, B, J)
+        A_mul_B_col_J!!(Y, p1inv, B, J+1)
+    end
+
+    copy!(B, Y)
+    fill!(Y, zero(eltype(Y)))
+    copy!(Y, 1, B, 1, 3M)
+
+    for j = 3:2:N÷2
+        if checklayer(j-1)
+            At_mul_B_col_J!(Y, BF[j-1], B, 2j)
+            At_mul_B_col_J!(Y, BF[j-1], B, 2j+1)
+        else
+            ℓ = round(Int, (j-1)÷LAYERSKELETON)*LAYERSKELETON
+            if ℓ > LAYERSKELETON-2
+                At_mul_B_col_J!(Y, BF[ℓ], B, 2j)
+                At_mul_B_col_J!(Y, BF[ℓ], B, 2j+1)
+            else
+                copy!(Y, 1+M*(2j-1), B, 1+M*(2j-1), 2M)
+            end
+            At_mul_B_col_J!(RP, Y, 2j, ℓ+1, j-1)
+            At_mul_B_col_J!(RP, Y, 2j+1, ℓ+1, j-1)
+        end
+    end
+
+    for j = 2:2:N÷2
+        if checklayer(j)
+            At_mul_B_col_J!(Y, BF[j-1], B, 2j)
+            At_mul_B_col_J!(Y, BF[j-1], B, 2j+1)
+        else
+            ℓ = round(Int, j÷LAYERSKELETON)*LAYERSKELETON
+            if ℓ > LAYERSKELETON-2
+                At_mul_B_col_J!(Y, BF[ℓ-1], B, 2j)
+                At_mul_B_col_J!(Y, BF[ℓ-1], B, 2j+1)
+            else
+                copy!(Y, 1+M*(2j-1), B, 1+M*(2j-1), 2M)
+            end
+            At_mul_B_col_J!(RP, Y, 2j, ℓ, j-1)
+            At_mul_B_col_J!(RP, Y, 2j+1, ℓ, j-1)
+        end
+    end
+
+    zero_spurious_modes!(Y)
+end
+
+Ac_mul_B!(Y::Matrix, TP::ThinSphericalHarmonicPlan, X::Matrix) = At_mul_B!(Y, TP, X)
+
+allranks(TP::ThinSphericalHarmonicPlan) = mapreduce(i->allranks(TP.BF[i]),vcat,sort!([LAYERSKELETON-1:LAYERSKELETON:length(TP.BF);LAYERSKELETON:LAYERSKELETON:length(TP.BF)]))
+
+
+function A_mul_B_col_J!(P::RotationPlan, A::AbstractMatrix, J::Int, L1::Int, L2::Int)
+    M, N = size(A)
+    @inbounds for m = L2-1:-2:L1
+        layer = P.layers[m+1]
+        @simd for i = 1:length(layer)
+            G = layer[i]
+            a1, a2 = A[G.i1,J], A[G.i2,J]
+            A[G.i1,J] = G.c*a1 + G.s*a2
+            A[G.i2,J] = G.c*a2 - G.s*a1
+        end
+    end
+    A
+end
+
+function At_mul_B_col_J!(P::RotationPlan, A::AbstractMatrix, J::Int, L1::Int, L2::Int)
+    M, N = size(A)
+    @inbounds for m = L1:2:L2-1
+        layer = P.layers[m+1]
+        @simd for i = length(layer):-1:1
+            G = layer[i]
+            a1, a2 = A[G.i1,J], A[G.i2,J]
+            A[G.i1,J] = G.c*a1 - G.s*a2
+            A[G.i2,J] = G.c*a2 + G.s*a1
+        end
+    end
+    A
+end

--- a/src/SphericalHarmonics/thinplan.jl
+++ b/src/SphericalHarmonics/thinplan.jl
@@ -42,7 +42,7 @@ end
 
 ThinSphericalHarmonicPlan(A::Matrix; opts...) = ThinSphericalHarmonicPlan(A, round(Int, log2(size(A, 1)+1)-6); opts...)
 
-function A_mul_B!(Y::Matrix, TP::ThinSphericalHarmonicPlan, X::Matrix)
+function Base.A_mul_B!(Y::Matrix, TP::ThinSphericalHarmonicPlan, X::Matrix)
     RP, BF, p1, p2, B = TP.RP, TP.BF, TP.p1, TP.p2, TP.B
     copy!(B, X)
     M, N = size(X)
@@ -98,7 +98,7 @@ function A_mul_B!(Y::Matrix, TP::ThinSphericalHarmonicPlan, X::Matrix)
 end
 
 
-function At_mul_B!(Y::Matrix, TP::ThinSphericalHarmonicPlan, X::Matrix)
+function Base.At_mul_B!(Y::Matrix, TP::ThinSphericalHarmonicPlan, X::Matrix)
     RP, BF, p1inv, p2inv, B = TP.RP, TP.BF, TP.p1inv, TP.p2inv, TP.B
     copy!(B, X)
     M, N = size(X)
@@ -153,7 +153,7 @@ function At_mul_B!(Y::Matrix, TP::ThinSphericalHarmonicPlan, X::Matrix)
     zero_spurious_modes!(Y)
 end
 
-Ac_mul_B!(Y::Matrix, TP::ThinSphericalHarmonicPlan, X::Matrix) = At_mul_B!(Y, TP, X)
+Base.Ac_mul_B!(Y::Matrix, TP::ThinSphericalHarmonicPlan, X::Matrix) = At_mul_B!(Y, TP, X)
 
 allranks(TP::ThinSphericalHarmonicPlan) = mapreduce(i->allranks(TP.BF[i]),vcat,sort!([LAYERSKELETON-1:LAYERSKELETON:length(TP.BF);LAYERSKELETON:LAYERSKELETON:length(TP.BF)]))
 

--- a/src/SphericalHarmonics/thinplan.jl
+++ b/src/SphericalHarmonics/thinplan.jl
@@ -26,7 +26,7 @@ function ThinSphericalHarmonicPlan{T}(A::Matrix{T}, L::Int; opts...)
     Ce = eye(T, M)
     Co = eye(T, M)
     BF = Vector{Butterfly{T}}(n-2)
-    P = Progress(n-2, 0.1, "Pre-computing thin plan...", 50)
+    P = Progress(n-2, 0.1, "Pre-computing...", 43)
     for j = 1:2:n-2
         A_mul_B!(Ce, RP.layers[j])
         checklayer(j+1) && (BF[j] = Butterfly(Ce, L; isorthogonal = true, opts...))

--- a/src/SphericalHarmonics/thinplan.jl
+++ b/src/SphericalHarmonics/thinplan.jl
@@ -27,13 +27,16 @@ function ThinSphericalHarmonicPlan{T}(A::Matrix{T}, L::Int; opts...)
     Ce = eye(T, M)
     Co = eye(T, M)
     BF = Vector{Butterfly{T}}(n-2)
+    P = Progress(n-2, 0.1, "Pre-computing thin plan...", 50)
     for j = 1:2:n-2
         A_mul_B!(Ce, RP.layers[j])
-        checklayer(j+1) && (BF[j] = orthogonalButterfly(Ce, L; opts...);println("Layer: ",j))
+        checklayer(j+1) && (BF[j] = Butterfly(Ce, L; isorthogonal = true, opts...))
+        next!(P)
     end
     for j = 2:2:n-2
         A_mul_B!(Co, RP.layers[j])
-        checklayer(j) && (BF[j] = orthogonalButterfly(Co, L; opts...);println("Layer: ",j))
+        checklayer(j) && (BF[j] = Butterfly(Co, L; isorthogonal = true, opts...))
+        next!(P)
     end
     ThinSphericalHarmonicPlan(RP, BF, p1, p2, p1inv, p2inv, B)
 end

--- a/src/SphericalHarmonics/thinplan.jl
+++ b/src/SphericalHarmonics/thinplan.jl
@@ -2,7 +2,7 @@ const LAYERSKELETON = 64
 
 checklayer(j::Int) = j÷LAYERSKELETON == j/LAYERSKELETON
 
-immutable ThinSphericalHarmonicPlan{T}
+immutable ThinSphericalHarmonicPlan{T} <: SphericalHarmonicPlan{T}
     RP::RotationPlan{T}
     BF::Vector{Butterfly{T}}
     p1::NormalizedLegendreToChebyshevPlan{T}
@@ -18,11 +18,10 @@ function ThinSphericalHarmonicPlan{T}(A::Matrix{T}, L::Int; opts...)
     @assert N == 2M-1
     n = (N+1)÷2
     RP = RotationPlan(T, n-1)
-    a1 = A[:,1]
-    p1 = plan_normleg2cheb(a1)
-    p2 = plan_normleg12cheb2(a1)
-    p1inv = plan_cheb2normleg(a1)
-    p2inv = plan_cheb22normleg1(a1)
+    p1 = plan_normleg2cheb(A)
+    p2 = plan_normleg12cheb2(A)
+    p1inv = plan_cheb2normleg(A)
+    p2inv = plan_cheb22normleg1(A)
     B = zeros(A)
     Ce = eye(T, M)
     Co = eye(T, M)

--- a/src/SphericalHarmonics/thinplan.jl
+++ b/src/SphericalHarmonics/thinplan.jl
@@ -12,7 +12,7 @@ immutable ThinSphericalHarmonicPlan{T}
     B::Matrix{T}
 end
 
-function ThinSphericalHarmonicPlan{T}(A::Matrix{T}, L::Int)
+function ThinSphericalHarmonicPlan{T}(A::Matrix{T}, L::Int; opts...)
     M, N = size(A)
     @assert ispow2(M)
     @assert N == 2M-1
@@ -29,16 +29,16 @@ function ThinSphericalHarmonicPlan{T}(A::Matrix{T}, L::Int)
     BF = Vector{Butterfly{T}}(n-2)
     for j = 1:2:n-2
         A_mul_B!(Ce, RP.layers[j])
-        checklayer(j+1) && (BF[j] = orthogonalButterfly(Ce, L);println("Layer: ",j))
+        checklayer(j+1) && (BF[j] = orthogonalButterfly(Ce, L; opts...);println("Layer: ",j))
     end
     for j = 2:2:n-2
         A_mul_B!(Co, RP.layers[j])
-        checklayer(j) && (BF[j] = orthogonalButterfly(Co, L);println("Layer: ",j))
+        checklayer(j) && (BF[j] = orthogonalButterfly(Co, L; opts...);println("Layer: ",j))
     end
     ThinSphericalHarmonicPlan(RP, BF, p1, p2, p1inv, p2inv, B)
 end
 
-ThinSphericalHarmonicPlan(A::Matrix) = ThinSphericalHarmonicPlan(A, round(Int, log2(size(A, 1)+1)-6))
+ThinSphericalHarmonicPlan(A::Matrix; opts...) = ThinSphericalHarmonicPlan(A, round(Int, log2(size(A, 1)+1)-6); opts...)
 
 function A_mul_B!(Y::Matrix, TP::ThinSphericalHarmonicPlan, X::Matrix)
     RP, BF, p1, p2, B = TP.RP, TP.BF, TP.p1, TP.p2, TP.B

--- a/src/hierarchical.jl
+++ b/src/hierarchical.jl
@@ -1,3 +1,72 @@
+@compat abstract type HierarchicalPlan{T} <: AbstractMatrix{T} end
+
+function *(P::HierarchicalPlan, x::AbstractVector)
+    A_mul_B!(zero(x), P, x)
+end
+
+function *(P::HierarchicalPlan, X::AbstractMatrix)
+    A_mul_B!(zero(X), P, X)
+end
+
+# A_mul_B!! mutates x while overwriting y. The generic fallback assumes it doesn't mutate x.
+A_mul_B!!(y::AbstractVector, P::HierarchicalPlan, x::AbstractVector) = A_mul_B!(y, P, x)
+A_mul_B!!(Y::AbstractMatrix, P::HierarchicalPlan, X::AbstractMatrix) = A_mul_B!(Y, P, X)
+A_mul_B_odd_cols!!(Y::AbstractMatrix, P::HierarchicalPlan, X::AbstractMatrix) = A_mul_B_odd_cols!(Y, P, X)
+A_mul_B_even_cols!!(Y::AbstractMatrix, P::HierarchicalPlan, X::AbstractMatrix) = A_mul_B_even_cols!(Y, P, X)
+
+# A_mul_B! falls back to the mutating version with a copy.
+A_mul_B!(y::AbstractVector, P::HierarchicalPlan, x::AbstractVector) = A_mul_B!!(y, P, copy(x))
+A_mul_B!(Y::AbstractMatrix, P::HierarchicalPlan, X::AbstractMatrix) = A_mul_B!!(Y, P, copy(X))
+A_mul_B_odd_cols!(Y::AbstractMatrix, P::HierarchicalPlan, X::AbstractMatrix) = A_mul_B_odd_cols!!(Y, P, copy(X))
+A_mul_B_even_cols!(Y::AbstractMatrix, P::HierarchicalPlan, X::AbstractMatrix) = A_mul_B_even_cols!!(Y, P, copy(X))
+
+function scale_odd_cols!(b::AbstractVector, A::AbstractMatrix)
+    m, n = size(A)
+    @inbounds for j = 1:2:n
+        @simd for i = 1:m
+            A[i,j] *= b[i]
+        end
+    end
+    A
+end
+
+function scale_odd_cols!(b::Number, A::AbstractMatrix)
+    m, n = size(A)
+    @inbounds for j = 1:2:n
+        @simd for i = 1:m
+            A[i,j] *= b
+        end
+    end
+    A
+end
+
+function scale_even_cols!(b::AbstractVector, A::AbstractMatrix)
+    m, n = size(A)
+    @inbounds for j = 2:2:n
+        @simd for i = 1:m
+            A[i,j] *= b[i]
+        end
+    end
+    A
+end
+
+function scale_even_cols!(b::Number, A::AbstractMatrix)
+    m, n = size(A)
+    @inbounds for j = 2:2:n
+        @simd for i = 1:m
+            A[i,j] *= b
+        end
+    end
+    A
+end
+
+@compat abstract type HierarchicalPlanWithParity{T} <: HierarchicalPlan{T} end
+
+size(P::HierarchicalPlanWithParity) = (size(P.even, 1)+size(P.odd, 1), size(P.even, 2)+size(P.odd, 2))
+
+evenlength(v::Vector) = (L = length(v); iseven(L) ? L÷2 : (L+1)÷2)
+oddlength(v::Vector) = (L = length(v); iseven(L) ? L÷2 : (L-1)÷2)
+
 UpperTriangularHierarchicalMatrix{T}(::Type{T}, f::Function, bd::Int64) = UpperTriangularHierarchicalMatrix(T, f, bd, bd)
 UpperTriangularHierarchicalMatrix{T}(::Type{T}, f::Function, b::Int64, d::Int64) = UpperTriangularHierarchicalMatrix(T, f, 1, b, 1, d)
 
@@ -79,29 +148,27 @@ function Lodd{T}(::Type{T}, x, y)
     end
 end
 
-immutable LegendreToChebyshevPlan{T} <: AbstractMatrix{T}
+immutable LegendreToChebyshevPlan{T} <: HierarchicalPlanWithParity{T}
     even::HierarchicalMatrix{T}
     odd::HierarchicalMatrix{T}
 end
 
-Base.size(P::LegendreToChebyshevPlan) = (size(P.even, 1)+size(P.odd, 1), size(P.even, 2)+size(P.odd, 2))
-function Base.getindex(P::LegendreToChebyshevPlan, i::Int, j::Int)
+function getindex(P::LegendreToChebyshevPlan, i::Int, j::Int)
     if isodd(i) && isodd(j)
-        P.even[(i+1)÷2,(j+1)÷2]
+        P.even[(i+1)÷2,(j+1)÷2]*(2-δ(i,1))/π
     elseif iseven(i) && iseven(j)
-        P.odd[i÷2,j÷2]
+        P.odd[i÷2,j÷2]*2/π
     else
         zero(eltype(P))
     end
 end
 
-immutable ChebyshevToLegendrePlan{T} <: AbstractMatrix{T}
+immutable ChebyshevToLegendrePlan{T} <: HierarchicalPlanWithParity{T}
     even::HierarchicalMatrix{T}
     odd::HierarchicalMatrix{T}
 end
 
-Base.size(P::ChebyshevToLegendrePlan) = (size(P.even, 1)+size(P.odd, 1), size(P.even, 2)+size(P.odd, 2))
-function Base.getindex(P::ChebyshevToLegendrePlan, i::Int, j::Int)
+function getindex(P::ChebyshevToLegendrePlan, i::Int, j::Int)
     if isodd(i) && isodd(j)
         P.even[(i+1)÷2,(j+1)÷2]
     elseif iseven(i) && iseven(j)
@@ -117,30 +184,305 @@ ChebyshevToLegendrePlan(v::Vector) = ChebyshevToLegendrePlan(plan_even_cheb2leg(
 plan_leg2cheb(v::Vector) = LegendreToChebyshevPlan(v)
 plan_cheb2leg(v::Vector) = ChebyshevToLegendrePlan(v)
 
-evenlength(v::Vector) = (L = length(v); iseven(L) ? L÷2 : (L+1)÷2)
-oddlength(v::Vector) = (L = length(v); iseven(L) ? L÷2 : (L-1)÷2)
-
 plan_even_leg2cheb(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Meven, evenlength(v))
 plan_odd_leg2cheb(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Modd, oddlength(v))
 
 plan_even_cheb2leg(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Leven, evenlength(v))
 plan_odd_cheb2leg(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Lodd, oddlength(v))
 
-function *(P::LegendreToChebyshevPlan,v::AbstractVector)
-    u = zero(v)
-    u[1:2:end] = P.even*view(v,1:2:length(v))
-    u[2:2:end] = P.odd*view(v,2:2:length(v))
-    scale!(2/π, u)
-    u[1] *= 0.5
-    u
-end
-
-function *(P::ChebyshevToLegendrePlan,v::AbstractVector)
-    u = zero(v)
-    u[1:2:end] = P.even*view(v,1:2:length(v))
-    u[2:2:end] = P.odd*view(v,2:2:length(v))
-    u
-end
-
 leg2cheb(v::Vector) = plan_leg2cheb(v)*v
 cheb2leg(v::Vector) = plan_cheb2leg(v)*v
+
+function A_mul_B!(y::Vector, P::LegendreToChebyshevPlan, x::AbstractVector)
+    A_mul_B!(y, P.even, x, 1, 1, 2, 2)
+    A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
+    scale!(2/π, y)
+    y[1] *= 0.5
+    y
+end
+
+function A_mul_B!(y::Vector, P::ChebyshevToLegendrePlan, x::AbstractVector)
+    A_mul_B!(y, P.even, x, 1, 1, 2, 2)
+    A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
+end
+
+function A_mul_B!(Y::Matrix, P::LegendreToChebyshevPlan, X::Matrix)
+    m, n = size(X)
+    for j = 1:n
+        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+    end
+    scale!(2/π, Y)
+    for j = 1:n
+        Y[1+m*(j-1)] *= 0.5
+    end
+    Y
+end
+
+function A_mul_B!(Y::Matrix, P::ChebyshevToLegendrePlan, X::Matrix)
+    m, n = size(X)
+    for j = 1:n
+        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+    end
+    Y
+end
+
+################################################################################
+# NORMLEG2CHEB
+
+function Mevennorm{T}(::Type{T}, x, y)
+    T(Λ(1.0*(y-x)).*Λ(1.0*(y+x-2)))
+end
+
+function Moddnorm{T}(::Type{T}, x, y)
+    T(Λ(1.0*(y-x)).*Λ(1.0*(y+x-1)))
+end
+
+function Levennorm{T}(::Type{T}, x, y)
+    if x == y
+        if x == 1.0
+            two(T)
+        else
+            T(sqrt(π)/2/Λ(2.0*(x-1.0))/(2.0*x-1.5))
+        end
+    else
+        T(-(y-1.0)/(2.0*x+2.0*y-3.0)/(y-x)*Λ(1.0*(y-x-1.0)).*Λ(1.0*(y+x-2.5)))
+    end
+end
+
+function Loddnorm{T}(::Type{T}, x, y)
+    if x == y
+        if x == 1.0
+            two(T)/T(3)
+        else
+            T(sqrt(π)/2/Λ(2.0*x-1.0)/(2.0*x-0.5))
+        end
+    else
+        T(-(2.0*y-1.0)/(2.0*x+2.0*y-1.0)/(2.0*y-2.0*x)*Λ(1.0*(y-x-1)).*Λ(0.5*(2.0*y+2.0*x-3)))
+    end
+end
+
+immutable NormalizedLegendreToChebyshevPlan{T} <: HierarchicalPlanWithParity{T}
+    even::HierarchicalMatrix{T}
+    odd::HierarchicalMatrix{T}
+    scl::Vector{T}
+end
+
+function getindex(P::NormalizedLegendreToChebyshevPlan, i::Int, j::Int)
+    if isodd(i) && isodd(j)
+        P.even[(i+1)÷2,(j+1)÷2]*(2-δ(i,1))/π*P.scl[j]
+    elseif iseven(i) && iseven(j)
+        P.odd[i÷2,j÷2]*2/π*P.scl[j]
+    else
+        zero(eltype(P))
+    end
+end
+
+immutable ChebyshevToNormalizedLegendrePlan{T} <: HierarchicalPlanWithParity{T}
+    even::HierarchicalMatrix{T}
+    odd::HierarchicalMatrix{T}
+    scl::Vector{T}
+end
+
+function getindex(P::ChebyshevToNormalizedLegendrePlan, i::Int, j::Int)
+    if isodd(i) && isodd(j)
+        P.even[(i+1)÷2,(j+1)÷2]*P.scl[i]
+    elseif iseven(i) && iseven(j)
+        P.odd[i÷2,j÷2]*P.scl[i]
+    else
+        zero(eltype(P))
+    end
+end
+
+NormalizedLegendreToChebyshevPlan(v::Vector) = NormalizedLegendreToChebyshevPlan(plan_even_normleg2cheb(v), plan_odd_normleg2cheb(v), eltype(v)[sqrt(j-0.5) for j in 1:length(v)])
+ChebyshevToNormalizedLegendrePlan(v::Vector) = ChebyshevToNormalizedLegendrePlan(plan_even_cheb2normleg(v), plan_odd_cheb2normleg(v), eltype(v)[sqrt(i-0.5) for i in 1:length(v)])
+
+plan_normleg2cheb(v::Vector) = NormalizedLegendreToChebyshevPlan(v)
+plan_cheb2normleg(v::Vector) = ChebyshevToNormalizedLegendrePlan(v)
+
+plan_even_normleg2cheb(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Mevennorm, evenlength(v))
+plan_odd_normleg2cheb(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Moddnorm, oddlength(v))
+
+plan_even_cheb2normleg(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Levennorm, evenlength(v))
+plan_odd_cheb2normleg(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Loddnorm, oddlength(v))
+
+normleg2cheb(v::Vector) = plan_normleg2cheb(v)*v
+cheb2normleg(v::Vector) = plan_cheb2normleg(v)*v
+
+function A_mul_B!!(y::Vector, P::NormalizedLegendreToChebyshevPlan, x::AbstractVector)
+    unsafe_broadcasttimes!(x, P.scl)
+    A_mul_B!(y, P.even, x, 1, 1, 2, 2)
+    A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
+    scale!(2/π, y)
+    y[1] *= 0.5
+    y
+end
+
+function A_mul_B!(y::Vector, P::ChebyshevToNormalizedLegendrePlan, x::AbstractVector)
+    A_mul_B!(y, P.even, x, 1, 1, 2, 2)
+    A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
+    unsafe_broadcasttimes!(y, P.scl)
+end
+
+function A_mul_B!!(Y::Matrix, P::NormalizedLegendreToChebyshevPlan, X::Matrix)
+    m, n = size(X)
+    scale!(P.scl, X)
+    for j = 1:n
+        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+    end
+    scale!(2/π, Y)
+    @inbounds @simd for j = 1:n
+        Y[1+m*(j-1)] *= 0.5
+    end
+    Y
+end
+
+function A_mul_B!(Y::Matrix, P::ChebyshevToNormalizedLegendrePlan, X::Matrix)
+    m, n = size(X)
+    for j = 1:n
+        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+    end
+    scale!(P.scl, Y)
+end
+
+function A_mul_B_odd_cols!!(Y::Matrix, P::NormalizedLegendreToChebyshevPlan, X::Matrix)
+    m, n = size(X)
+    scale_odd_cols!(P.scl, X)
+    for j = 1:2:n
+        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+    end
+    scale_odd_cols!(2/π, Y)
+    @inbounds @simd for j = 1:2:n
+        Y[1+m*(j-1)] *= 0.5
+    end
+    Y
+end
+
+function A_mul_B_odd_cols!(Y::Matrix, P::ChebyshevToNormalizedLegendrePlan, X::Matrix)
+    m, n = size(X)
+    for j = 1:2:n
+        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+    end
+    scale_odd_cols!(P.scl, Y)
+end
+
+################################################################################
+# NORMLEG12CHEB2
+
+function Mnormeven{T}(::Type{T}, x, y)
+    T(Λ(1.0*(y-x))*Λ(1.0*(y+x-1))*(4.0*x-2.0)/π)
+end
+
+function Mnormodd{T}(::Type{T}, x, y)
+    T(Λ(1.0*(y-x))*Λ(1.0*(y+x))*(4.0*x)/π)
+end
+
+function Lnormeven{T}(::Type{T}, x, y)
+    -T(Λ(1.0*(y-x))/(2.0*y-2.0*x-1.0)*Λ(1.0*(y+x-1)+0.5)/(2.0*y+2.0*x-2.0)*(2.0*x-0.5))
+end
+
+function Lnormodd{T}(::Type{T}, x, y)
+    -T(Λ(1.0*(y-x))/(2.0*y-2.0*x-1.0)*Λ(1.0*(y+x)+0.5)/(2.0*y+2.0*x)*(2.0*x+0.5))
+end
+
+immutable NormalizedLegendre1ToChebyshev2Plan{T} <: HierarchicalPlanWithParity{T}
+    even::HierarchicalMatrix{T}
+    odd::HierarchicalMatrix{T}
+    scl::Vector{T}
+end
+
+function getindex(P::NormalizedLegendre1ToChebyshev2Plan, i::Int, j::Int)
+    if isodd(i) && isodd(j)
+        P.even[(i+1)÷2,(j+1)÷2]*P.scl[j]
+    elseif iseven(i) && iseven(j)
+        P.odd[i÷2,j÷2]*P.scl[j]
+    else
+        zero(eltype(P))
+    end
+end
+
+immutable Chebyshev2ToNormalizedLegendre1Plan{T} <: HierarchicalPlanWithParity{T}
+    even::HierarchicalMatrix{T}
+    odd::HierarchicalMatrix{T}
+    scl::Vector{T}
+end
+
+function getindex(P::Chebyshev2ToNormalizedLegendre1Plan, i::Int, j::Int)
+    if isodd(i) && isodd(j)
+        P.even[(i+1)÷2,(j+1)÷2]*P.scl[i]
+    elseif iseven(i) && iseven(j)
+        P.odd[i÷2,j÷2]*P.scl[i]
+    else
+        zero(eltype(P))
+    end
+end
+
+NormalizedLegendre1ToChebyshev2Plan(v::Vector) = NormalizedLegendre1ToChebyshev2Plan(plan_even_normleg12cheb2(v), plan_odd_normleg12cheb2(v), eltype(v)[sqrt((j+0.5)/(j*(j+1))) for j in 1:length(v)])
+Chebyshev2ToNormalizedLegendre1Plan(v::Vector) = Chebyshev2ToNormalizedLegendre1Plan(plan_even_cheb22normleg1(v), plan_odd_cheb22normleg1(v), eltype(v)[sqrt(i*(i+1)/(i+0.5)) for i in 1:length(v)])
+
+plan_normleg12cheb2(v::Vector) = NormalizedLegendre1ToChebyshev2Plan(v)
+plan_cheb22normleg1(v::Vector) = Chebyshev2ToNormalizedLegendre1Plan(v)
+
+plan_even_normleg12cheb2(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Mnormeven, evenlength(v))
+plan_odd_normleg12cheb2(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Mnormodd, oddlength(v))
+
+plan_even_cheb22normleg1(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Lnormeven, evenlength(v))
+plan_odd_cheb22normleg1(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Lnormodd, oddlength(v))
+
+normleg12cheb2(v::Vector) = plan_normleg12cheb2(v)*v
+cheb22normleg1(v::Vector) = plan_cheb22normleg1(v)*v
+
+function A_mul_B!!(y::Vector, P::NormalizedLegendre1ToChebyshev2Plan, x::AbstractVector)
+    unsafe_broadcasttimes!(x, P.scl)
+    A_mul_B!(y, P.even, x, 1, 1, 2, 2)
+    A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
+end
+
+function A_mul_B!(y::Vector, P::Chebyshev2ToNormalizedLegendre1Plan, x::AbstractVector)
+    A_mul_B!(y, P.even, x, 1, 1, 2, 2)
+    A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
+    unsafe_broadcasttimes!(y, P.scl)
+end
+
+function A_mul_B!!(Y::Matrix, P::NormalizedLegendre1ToChebyshev2Plan, X::Matrix)
+    m, n = size(X)
+    scale!(P.scl, X)
+    for j = 1:n
+        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+    end
+    Y
+end
+
+function A_mul_B!(Y::Matrix, P::Chebyshev2ToNormalizedLegendre1Plan, X::Matrix)
+    m, n = size(X)
+    for j = 1:n
+        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+    end
+    scale!(P.scl, Y)
+end
+
+function A_mul_B_even_cols!!(Y::Matrix, P::NormalizedLegendre1ToChebyshev2Plan, X::Matrix)
+    m, n = size(X)
+    scale_even_cols!(P.scl, X)
+    for j = 2:2:n
+        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+    end
+    Y
+end
+
+function A_mul_B_even_cols!(Y::Matrix, P::Chebyshev2ToNormalizedLegendre1Plan, X::Matrix)
+    m, n = size(X)
+    for j = 2:2:n
+        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+    end
+    scale_even_cols!(P.scl, Y)
+end

--- a/src/hierarchical.jl
+++ b/src/hierarchical.jl
@@ -40,8 +40,8 @@ end
 
 size(P::HierarchicalPlanWithParity) = (size(P.even, 1)+size(P.odd, 1), size(P.even, 2)+size(P.odd, 2))
 
-evenlength(v::Vector) = (L = length(v); iseven(L) ? L÷2 : (L+1)÷2)
-oddlength(v::Vector) = (L = length(v); iseven(L) ? L÷2 : (L-1)÷2)
+evensize(v::AbstractVecOrMat, d) = (L = size(v, d); iseven(L) ? L÷2 : (L+1)÷2)
+oddsize(v::AbstractVecOrMat, d) = (L = size(v, d); iseven(L) ? L÷2 : (L-1)÷2)
 
 UpperTriangularHierarchicalMatrix{T}(::Type{T}, f::Function, bd::Int64) = UpperTriangularHierarchicalMatrix(T, f, bd, bd)
 UpperTriangularHierarchicalMatrix{T}(::Type{T}, f::Function, b::Int64, d::Int64) = UpperTriangularHierarchicalMatrix(T, f, 1, b, 1, d)
@@ -154,21 +154,6 @@ function getindex(P::ChebyshevToLegendrePlan, i::Int, j::Int)
     end
 end
 
-LegendreToChebyshevPlan(v::Vector) = LegendreToChebyshevPlan(plan_even_leg2cheb(v), plan_odd_leg2cheb(v))
-ChebyshevToLegendrePlan(v::Vector) = ChebyshevToLegendrePlan(plan_even_cheb2leg(v), plan_odd_cheb2leg(v))
-
-plan_leg2cheb(v::Vector) = LegendreToChebyshevPlan(v)
-plan_cheb2leg(v::Vector) = ChebyshevToLegendrePlan(v)
-
-plan_even_leg2cheb(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Meven, evenlength(v))
-plan_odd_leg2cheb(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Modd, oddlength(v))
-
-plan_even_cheb2leg(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Leven, evenlength(v))
-plan_odd_cheb2leg(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Lodd, oddlength(v))
-
-leg2cheb(v::Vector) = plan_leg2cheb(v)*v
-cheb2leg(v::Vector) = plan_cheb2leg(v)*v
-
 function A_mul_B!(y::Vector, P::LegendreToChebyshevPlan, x::AbstractVector)
     HierarchicalMatrices.A_mul_B!(y, P.even, x, 1, 1, 2, 2)
     HierarchicalMatrices.A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
@@ -270,21 +255,6 @@ function getindex(P::ChebyshevToNormalizedLegendrePlan, i::Int, j::Int)
         zero(eltype(P))
     end
 end
-
-NormalizedLegendreToChebyshevPlan(v::Vector) = NormalizedLegendreToChebyshevPlan(plan_even_normleg2cheb(v), plan_odd_normleg2cheb(v), eltype(v)[sqrt(j-0.5) for j in 1:length(v)])
-ChebyshevToNormalizedLegendrePlan(v::Vector) = ChebyshevToNormalizedLegendrePlan(plan_even_cheb2normleg(v), plan_odd_cheb2normleg(v), eltype(v)[sqrt(i-0.5) for i in 1:length(v)])
-
-plan_normleg2cheb(v::Vector) = NormalizedLegendreToChebyshevPlan(v)
-plan_cheb2normleg(v::Vector) = ChebyshevToNormalizedLegendrePlan(v)
-
-plan_even_normleg2cheb(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Mevennorm, evenlength(v))
-plan_odd_normleg2cheb(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Moddnorm, oddlength(v))
-
-plan_even_cheb2normleg(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Levennorm, evenlength(v))
-plan_odd_cheb2normleg(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Loddnorm, oddlength(v))
-
-normleg2cheb(v::Vector) = plan_normleg2cheb(v)*v
-cheb2normleg(v::Vector) = plan_cheb2normleg(v)*v
 
 function A_mul_B!!(y::Vector, P::NormalizedLegendreToChebyshevPlan, x::AbstractVector)
     unsafe_broadcasttimes!(x, P.scl)
@@ -394,21 +364,6 @@ function getindex(P::Chebyshev2ToNormalizedLegendre1Plan, i::Int, j::Int)
     end
 end
 
-NormalizedLegendre1ToChebyshev2Plan(v::Vector) = NormalizedLegendre1ToChebyshev2Plan(plan_even_normleg12cheb2(v), plan_odd_normleg12cheb2(v), eltype(v)[sqrt((j+0.5)/(j*(j+1))) for j in 1:length(v)])
-Chebyshev2ToNormalizedLegendre1Plan(v::Vector) = Chebyshev2ToNormalizedLegendre1Plan(plan_even_cheb22normleg1(v), plan_odd_cheb22normleg1(v), eltype(v)[sqrt(i*(i+1)/(i+0.5)) for i in 1:length(v)])
-
-plan_normleg12cheb2(v::Vector) = NormalizedLegendre1ToChebyshev2Plan(v)
-plan_cheb22normleg1(v::Vector) = Chebyshev2ToNormalizedLegendre1Plan(v)
-
-plan_even_normleg12cheb2(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Mnormeven, evenlength(v))
-plan_odd_normleg12cheb2(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Mnormodd, oddlength(v))
-
-plan_even_cheb22normleg1(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Lnormeven, evenlength(v))
-plan_odd_cheb22normleg1(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Lnormodd, oddlength(v))
-
-normleg12cheb2(v::Vector) = plan_normleg12cheb2(v)*v
-cheb22normleg1(v::Vector) = plan_cheb22normleg1(v)*v
-
 function A_mul_B!!(y::Vector, P::NormalizedLegendre1ToChebyshev2Plan, x::AbstractVector)
     unsafe_broadcasttimes!(x, P.scl)
     HierarchicalMatrices.A_mul_B!(y, P.even, x, 1, 1, 2, 2)
@@ -456,3 +411,31 @@ function A_mul_B_col_J!(Y::Matrix, P::Chebyshev2ToNormalizedLegendre1Plan, X::Ma
     HierarchicalMatrices.A_mul_B!(Y, P.odd, X, 2+COLSHIFT, 2+COLSHIFT, 2, 2)
     scale_col_J!(P.scl, Y, J)
 end
+
+### API
+
+for (f, T, feven, fodd) in ((:leg2cheb, :LegendreToChebyshevPlan, :Meven, :Modd),
+                          (:cheb2leg, :ChebyshevToLegendrePlan, :Leven, :Lodd),
+                          (:normleg2cheb, :NormalizedLegendreToChebyshevPlan, :Mevennorm, :Moddnorm),
+                          (:cheb2normleg, :ChebyshevToNormalizedLegendrePlan, :Levennorm, :Loddnorm),
+                          (:normleg12cheb2, :NormalizedLegendre1ToChebyshev2Plan, :Mnormeven, :Mnormodd),
+                          (:cheb22normleg1, :Chebyshev2ToNormalizedLegendre1Plan, :Lnormeven, :Lnormodd))
+    plan_f = parse("plan_"*string(f))
+    plan_even_f = parse("plan_even_"*string(f))
+    plan_odd_f = parse("plan_odd_"*string(f))
+    @eval begin
+        $plan_f(v::VecOrMat) = $T(v)
+        $f(v::VecOrMat) = $plan_f(v)*v
+        $plan_even_f(v::VecOrMat) = UpperTriangularHierarchicalMatrix(eltype(v), $feven, evensize(v, 1))
+        $plan_odd_f(v::VecOrMat) = UpperTriangularHierarchicalMatrix(eltype(v), $fodd, oddsize(v, 1))
+    end
+end
+
+LegendreToChebyshevPlan(v::VecOrMat) = LegendreToChebyshevPlan(plan_even_leg2cheb(v), plan_odd_leg2cheb(v))
+ChebyshevToLegendrePlan(v::VecOrMat) = ChebyshevToLegendrePlan(plan_even_cheb2leg(v), plan_odd_cheb2leg(v))
+
+NormalizedLegendreToChebyshevPlan(v::VecOrMat) = NormalizedLegendreToChebyshevPlan(plan_even_normleg2cheb(v), plan_odd_normleg2cheb(v), eltype(v)[sqrt(j-0.5) for j in 1:size(v, 1)])
+ChebyshevToNormalizedLegendrePlan(v::VecOrMat) = ChebyshevToNormalizedLegendrePlan(plan_even_cheb2normleg(v), plan_odd_cheb2normleg(v), eltype(v)[sqrt(i-0.5) for i in 1:size(v, 1)])
+
+NormalizedLegendre1ToChebyshev2Plan(v::VecOrMat) = NormalizedLegendre1ToChebyshev2Plan(plan_even_normleg12cheb2(v), plan_odd_normleg12cheb2(v), eltype(v)[sqrt((j+0.5)/(j*(j+1))) for j in 1:size(v, 1)])
+Chebyshev2ToNormalizedLegendre1Plan(v::VecOrMat) = Chebyshev2ToNormalizedLegendre1Plan(plan_even_cheb22normleg1(v), plan_odd_cheb22normleg1(v), eltype(v)[sqrt(i*(i+1)/(i+0.5)) for i in 1:size(v, 1)])

--- a/src/hierarchical.jl
+++ b/src/hierarchical.jl
@@ -439,3 +439,31 @@ ChebyshevToNormalizedLegendrePlan(v::VecOrMat) = ChebyshevToNormalizedLegendrePl
 
 NormalizedLegendre1ToChebyshev2Plan(v::VecOrMat) = NormalizedLegendre1ToChebyshev2Plan(plan_even_normleg12cheb2(v), plan_odd_normleg12cheb2(v), eltype(v)[sqrt((j+0.5)/(j*(j+1))) for j in 1:size(v, 1)])
 Chebyshev2ToNormalizedLegendre1Plan(v::VecOrMat) = Chebyshev2ToNormalizedLegendre1Plan(plan_even_cheb22normleg1(v), plan_odd_cheb22normleg1(v), eltype(v)[sqrt(i*(i+1)/(i+0.5)) for i in 1:size(v, 1)])
+
+doc"""
+Computes the Chebyshev expansion coefficients given the Legendre expansion coefficients:
+
+```math
+{\rm CLT} : \sum_{n=0}^N c_n^{\rm leg}P_n(x) \to \sum_{n=0}^N c_n^{\rm cheb}T_n(x).
+```
+"""
+leg2cheb(::Vector)
+
+doc"""
+Computes the Legendre expansion coefficients given the Chebyshev expansion coefficients:
+
+```math
+{\rm iCLT} : \sum_{n=0}^N c_n^{\rm cheb}T_n(x) \to \sum_{n=0}^N c_n^{\rm leg}P_n(x).
+```
+"""
+cheb2leg(::Vector)
+
+doc"""
+Pre-computes the Legendre--Chebyshev transform.
+"""
+plan_leg2cheb(::Vector)
+
+doc"""
+Pre-computes the Chebyshev--Legendre transform.
+"""
+plan_cheb2leg(::Vector)

--- a/src/hierarchical.jl
+++ b/src/hierarchical.jl
@@ -1,0 +1,146 @@
+UpperTriangularHierarchicalMatrix{T}(::Type{T}, f::Function, bd::Int64) = UpperTriangularHierarchicalMatrix(T, f, bd, bd)
+UpperTriangularHierarchicalMatrix{T}(::Type{T}, f::Function, b::Int64, d::Int64) = UpperTriangularHierarchicalMatrix(T, f, 1, b, 1, d)
+
+function UpperTriangularHierarchicalMatrix{T}(::Type{T}, f::Function, a::Int64, b::Int64, c::Int64, d::Int64)
+    if (b-a+1) < BLOCKSIZE(T) && (d-c+1) < BLOCKSIZE(T)
+        i = (b-a)÷2
+        j = (d-c)÷2
+        H = HierarchicalMatrix(T, 2, 2)
+        H[Block(1), Block(1)] = T[j ≥ i ? f(T,i,j) : zero(T) for i=a:a+i, j=c:c+j]
+        H[Block(1), Block(2)] = T[f(T,i,j) for i=a:a+i, j=c+j+1:d]
+        H[Block(2), Block(2)] = T[j ≥ i ? f(T,i,j) : zero(T) for i=a+i+1:b, j=c+j+1:d]
+
+        H
+    else
+        i = (b-a)÷2
+        j = (d-c)÷2
+        H = HierarchicalMatrix(T, 2, 2)
+        H[Block(1), Block(1)] = UpperTriangularHierarchicalMatrix(T, f, a, a+i, c, c+j)
+        H[Block(1), Block(2)] = HierarchicalMatrix(T, f, a, a+i, c+j+1, d)
+        H[Block(2), Block(2)] = UpperTriangularHierarchicalMatrix(T, f, a+i+1, b, c+j+1, d)
+
+        H
+    end
+end
+
+function HierarchicalMatrix{T}(::Type{T}, f::Function, a::Int64, b::Int64, c::Int64, d::Int64)
+    if (b-a+1) < BLOCKSIZE(T) && (d-c+1) < BLOCKSIZE(T)
+        i = (b-a)÷2
+        j = (d-c)÷2
+        H = HierarchicalMatrix(T, 2, 2)
+        H[Block(1), Block(1)] = barycentricmatrix(T, f, a, a+i, c, c+j)
+        H[Block(1), Block(2)] = barycentricmatrix(T, f, a, a+i, c+j+1, d)
+        H[Block(2), Block(1)] = T[f(T,i,j) for i=a+i+1:b, j=c:c+j]
+        H[Block(2), Block(2)] = barycentricmatrix(T, f, a+i+1, b, c+j+1, d)
+
+        H
+    else
+        i = (b-a)÷2
+        j = (d-c)÷2
+        H = HierarchicalMatrix(T, 2, 2)
+        H[Block(1), Block(1)] = barycentricmatrix(T, f, a, a+i, c, c+j)
+        H[Block(1), Block(2)] = barycentricmatrix(T, f, a, a+i, c+j+1, d)
+        H[Block(2), Block(1)] = HierarchicalMatrix(T, f, a+i+1, b, c, c+j)
+        H[Block(2), Block(2)] = barycentricmatrix(T, f, a+i+1, b, c+j+1, d)
+
+        H
+    end
+end
+
+function Meven{T}(::Type{T}, x, y)
+    T(Λ(1.0*(y-x)).*Λ(1.0*(y+x-2)))
+end
+
+function Modd{T}(::Type{T}, x, y)
+    T(Λ(1.0*(y-x)).*Λ(1.0*(y+x-1)))
+end
+
+function Leven{T}(::Type{T}, x, y)
+    if x == y
+        if x == 1.0
+            T(1.0)
+        else
+            T(sqrt(π)/2/Λ(2.0*(x-1.0)))
+        end
+    else
+        T(-(y-1.0)*(2.0*x-1.5)/(2.0*x+2.0*y-3.0)/(y-x)*Λ(1.0*(y-x-1.0)).*Λ(1.0*(y+x-2.5)))
+    end
+end
+
+function Lodd{T}(::Type{T}, x, y)
+    if x == y
+        if x == 1.0
+            T(1.0)
+        else
+            T(sqrt(π)/2/Λ(2.0*x-1.0))
+        end
+    else
+        T(-(2.0*y-1.0)*(2.0*x-0.5)/(2.0*x+2.0*y-1.0)/(2.0*y-2.0*x)*Λ(1.0*(y-x-1)).*Λ(0.5*(2.0*y+2.0*x-3)))
+    end
+end
+
+immutable LegendreToChebyshevPlan{T} <: AbstractMatrix{T}
+    even::HierarchicalMatrix{T}
+    odd::HierarchicalMatrix{T}
+end
+
+Base.size(P::LegendreToChebyshevPlan) = (size(P.even, 1)+size(P.odd, 1), size(P.even, 2)+size(P.odd, 2))
+function Base.getindex(P::LegendreToChebyshevPlan, i::Int, j::Int)
+    if isodd(i) && isodd(j)
+        P.even[(i+1)÷2,(j+1)÷2]
+    elseif iseven(i) && iseven(j)
+        P.odd[i÷2,j÷2]
+    else
+        zero(eltype(P))
+    end
+end
+
+immutable ChebyshevToLegendrePlan{T} <: AbstractMatrix{T}
+    even::HierarchicalMatrix{T}
+    odd::HierarchicalMatrix{T}
+end
+
+Base.size(P::ChebyshevToLegendrePlan) = (size(P.even, 1)+size(P.odd, 1), size(P.even, 2)+size(P.odd, 2))
+function Base.getindex(P::ChebyshevToLegendrePlan, i::Int, j::Int)
+    if isodd(i) && isodd(j)
+        P.even[(i+1)÷2,(j+1)÷2]
+    elseif iseven(i) && iseven(j)
+        P.odd[i÷2,j÷2]
+    else
+        zero(eltype(P))
+    end
+end
+
+LegendreToChebyshevPlan(v::Vector) = LegendreToChebyshevPlan(plan_even_leg2cheb(v), plan_odd_leg2cheb(v))
+ChebyshevToLegendrePlan(v::Vector) = ChebyshevToLegendrePlan(plan_even_cheb2leg(v), plan_odd_cheb2leg(v))
+
+plan_leg2cheb(v::Vector) = LegendreToChebyshevPlan(v)
+plan_cheb2leg(v::Vector) = ChebyshevToLegendrePlan(v)
+
+evenlength(v::Vector) = (L = length(v); iseven(L) ? L÷2 : (L+1)÷2)
+oddlength(v::Vector) = (L = length(v); iseven(L) ? L÷2 : (L-1)÷2)
+
+plan_even_leg2cheb(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Meven, evenlength(v))
+plan_odd_leg2cheb(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Modd, oddlength(v))
+
+plan_even_cheb2leg(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Leven, evenlength(v))
+plan_odd_cheb2leg(v::Vector) = UpperTriangularHierarchicalMatrix(eltype(v), Lodd, oddlength(v))
+
+function *(P::LegendreToChebyshevPlan,v::AbstractVector)
+    u = zero(v)
+    u[1:2:end] = P.even*view(v,1:2:length(v))
+    u[2:2:end] = P.odd*view(v,2:2:length(v))
+    scale!(2/π, u)
+    u[1] *= 0.5
+    u
+end
+
+function *(P::ChebyshevToLegendrePlan,v::AbstractVector)
+    u = zero(v)
+    u[1:2:end] = P.even*view(v,1:2:length(v))
+    u[2:2:end] = P.odd*view(v,2:2:length(v))
+    u
+end
+
+leg2cheb(v::Vector) = plan_leg2cheb(v)*v
+cheb2leg(v::Vector) = plan_cheb2leg(v)*v

--- a/src/hierarchical.jl
+++ b/src/hierarchical.jl
@@ -170,23 +170,23 @@ leg2cheb(v::Vector) = plan_leg2cheb(v)*v
 cheb2leg(v::Vector) = plan_cheb2leg(v)*v
 
 function A_mul_B!(y::Vector, P::LegendreToChebyshevPlan, x::AbstractVector)
-    A_mul_B!(y, P.even, x, 1, 1, 2, 2)
-    A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
+    HierarchicalMatrices.A_mul_B!(y, P.even, x, 1, 1, 2, 2)
+    HierarchicalMatrices.A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
     scale!(2/π, y)
     y[1] *= 0.5
     y
 end
 
 function A_mul_B!(y::Vector, P::ChebyshevToLegendrePlan, x::AbstractVector)
-    A_mul_B!(y, P.even, x, 1, 1, 2, 2)
-    A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
+    HierarchicalMatrices.A_mul_B!(y, P.even, x, 1, 1, 2, 2)
+    HierarchicalMatrices.A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
 end
 
 function A_mul_B!(Y::Matrix, P::LegendreToChebyshevPlan, X::Matrix)
     m, n = size(X)
     for j = 1:n
-        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
-        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+        HierarchicalMatrices.A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        HierarchicalMatrices.A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
     end
     scale!(2/π, Y)
     for j = 1:n
@@ -198,8 +198,8 @@ end
 function A_mul_B!(Y::Matrix, P::ChebyshevToLegendrePlan, X::Matrix)
     m, n = size(X)
     for j = 1:n
-        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
-        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+        HierarchicalMatrices.A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        HierarchicalMatrices.A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
     end
     Y
 end
@@ -288,16 +288,16 @@ cheb2normleg(v::Vector) = plan_cheb2normleg(v)*v
 
 function A_mul_B!!(y::Vector, P::NormalizedLegendreToChebyshevPlan, x::AbstractVector)
     unsafe_broadcasttimes!(x, P.scl)
-    A_mul_B!(y, P.even, x, 1, 1, 2, 2)
-    A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
+    HierarchicalMatrices.A_mul_B!(y, P.even, x, 1, 1, 2, 2)
+    HierarchicalMatrices.A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
     scale!(2/π, y)
     y[1] *= 0.5
     y
 end
 
 function A_mul_B!(y::Vector, P::ChebyshevToNormalizedLegendrePlan, x::AbstractVector)
-    A_mul_B!(y, P.even, x, 1, 1, 2, 2)
-    A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
+    HierarchicalMatrices.A_mul_B!(y, P.even, x, 1, 1, 2, 2)
+    HierarchicalMatrices.A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
     unsafe_broadcasttimes!(y, P.scl)
 end
 
@@ -305,8 +305,8 @@ function A_mul_B!!(Y::Matrix, P::NormalizedLegendreToChebyshevPlan, X::Matrix)
     m, n = size(X)
     scale!(P.scl, X)
     for j = 1:n
-        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
-        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+        HierarchicalMatrices.A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        HierarchicalMatrices.A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
     end
     scale!(2/π, Y)
     @inbounds @simd for j = 1:n
@@ -318,8 +318,8 @@ end
 function A_mul_B!(Y::Matrix, P::ChebyshevToNormalizedLegendrePlan, X::Matrix)
     m, n = size(X)
     for j = 1:n
-        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
-        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+        HierarchicalMatrices.A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        HierarchicalMatrices.A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
     end
     scale!(P.scl, Y)
 end
@@ -328,8 +328,8 @@ function A_mul_B_col_J!!(Y::Matrix, P::NormalizedLegendreToChebyshevPlan, X::Mat
     m, n = size(X)
     COLSHIFT = m*(J-1)
     scale_col_J!(P.scl, X, J)
-    A_mul_B!(Y, P.even, X, 1+COLSHIFT, 1+COLSHIFT, 2, 2)
-    A_mul_B!(Y, P.odd, X, 2+COLSHIFT, 2+COLSHIFT, 2, 2)
+    HierarchicalMatrices.A_mul_B!(Y, P.even, X, 1+COLSHIFT, 1+COLSHIFT, 2, 2)
+    HierarchicalMatrices.A_mul_B!(Y, P.odd, X, 2+COLSHIFT, 2+COLSHIFT, 2, 2)
     scale_col_J!(2/π, Y, J)
     @inbounds Y[1+COLSHIFT] *= 0.5
     Y
@@ -338,8 +338,8 @@ end
 function A_mul_B_col_J!(Y::Matrix, P::ChebyshevToNormalizedLegendrePlan, X::Matrix, J::Int)
     m, n = size(X)
     COLSHIFT = m*(J-1)
-    A_mul_B!(Y, P.even, X, 1+COLSHIFT, 1+COLSHIFT, 2, 2)
-    A_mul_B!(Y, P.odd, X, 2+COLSHIFT, 2+COLSHIFT, 2, 2)
+    HierarchicalMatrices.A_mul_B!(Y, P.even, X, 1+COLSHIFT, 1+COLSHIFT, 2, 2)
+    HierarchicalMatrices.A_mul_B!(Y, P.odd, X, 2+COLSHIFT, 2+COLSHIFT, 2, 2)
     scale_col_J!(P.scl, Y, J)
 end
 
@@ -411,13 +411,13 @@ cheb22normleg1(v::Vector) = plan_cheb22normleg1(v)*v
 
 function A_mul_B!!(y::Vector, P::NormalizedLegendre1ToChebyshev2Plan, x::AbstractVector)
     unsafe_broadcasttimes!(x, P.scl)
-    A_mul_B!(y, P.even, x, 1, 1, 2, 2)
-    A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
+    HierarchicalMatrices.A_mul_B!(y, P.even, x, 1, 1, 2, 2)
+    HierarchicalMatrices.A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
 end
 
 function A_mul_B!(y::Vector, P::Chebyshev2ToNormalizedLegendre1Plan, x::AbstractVector)
-    A_mul_B!(y, P.even, x, 1, 1, 2, 2)
-    A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
+    HierarchicalMatrices.A_mul_B!(y, P.even, x, 1, 1, 2, 2)
+    HierarchicalMatrices.A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
     unsafe_broadcasttimes!(y, P.scl)
 end
 
@@ -425,8 +425,8 @@ function A_mul_B!!(Y::Matrix, P::NormalizedLegendre1ToChebyshev2Plan, X::Matrix)
     m, n = size(X)
     scale!(P.scl, X)
     for j = 1:n
-        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
-        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+        HierarchicalMatrices.A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        HierarchicalMatrices.A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
     end
     Y
 end
@@ -434,8 +434,8 @@ end
 function A_mul_B!(Y::Matrix, P::Chebyshev2ToNormalizedLegendre1Plan, X::Matrix)
     m, n = size(X)
     for j = 1:n
-        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
-        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+        HierarchicalMatrices.A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        HierarchicalMatrices.A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
     end
     scale!(P.scl, Y)
 end
@@ -444,15 +444,15 @@ function A_mul_B_col_J!!(Y::Matrix, P::NormalizedLegendre1ToChebyshev2Plan, X::M
     m, n = size(X)
     COLSHIFT = m*(J-1)
     scale_col_J!(P.scl, X, J)
-    A_mul_B!(Y, P.even, X, 1+COLSHIFT, 1+COLSHIFT, 2, 2)
-    A_mul_B!(Y, P.odd, X, 2+COLSHIFT, 2+COLSHIFT, 2, 2)
+    HierarchicalMatrices.A_mul_B!(Y, P.even, X, 1+COLSHIFT, 1+COLSHIFT, 2, 2)
+    HierarchicalMatrices.A_mul_B!(Y, P.odd, X, 2+COLSHIFT, 2+COLSHIFT, 2, 2)
     Y
 end
 
 function A_mul_B_col_J!(Y::Matrix, P::Chebyshev2ToNormalizedLegendre1Plan, X::Matrix, J::Int)
     m, n = size(X)
     COLSHIFT = m*(J-1)
-    A_mul_B!(Y, P.even, X, 1+COLSHIFT, 1+COLSHIFT, 2, 2)
-    A_mul_B!(Y, P.odd, X, 2+COLSHIFT, 2+COLSHIFT, 2, 2)
+    HierarchicalMatrices.A_mul_B!(Y, P.even, X, 1+COLSHIFT, 1+COLSHIFT, 2, 2)
+    HierarchicalMatrices.A_mul_B!(Y, P.odd, X, 2+COLSHIFT, 2+COLSHIFT, 2, 2)
     scale_col_J!(P.scl, Y, J)
 end

--- a/src/hierarchical.jl
+++ b/src/hierarchical.jl
@@ -14,8 +14,8 @@ A_mul_B!!(Y::AbstractMatrix, P::HierarchicalPlan, X::AbstractMatrix) = A_mul_B!(
 A_mul_B_col_J!!(Y::AbstractMatrix, P::HierarchicalPlan, X::AbstractMatrix, J::Int) = A_mul_B_col_J!(Y, P, X, J)
 
 # A_mul_B! falls back to the mutating version with a copy.
-A_mul_B!(y::AbstractVector, P::HierarchicalPlan, x::AbstractVector) = A_mul_B!!(y, P, copy(x))
-A_mul_B!(Y::AbstractMatrix, P::HierarchicalPlan, X::AbstractMatrix) = A_mul_B!!(Y, P, copy(X))
+Base.A_mul_B!(y::AbstractVector, P::HierarchicalPlan, x::AbstractVector) = A_mul_B!!(y, P, copy(x))
+Base.A_mul_B!(Y::AbstractMatrix, P::HierarchicalPlan, X::AbstractMatrix) = A_mul_B!!(Y, P, copy(X))
 A_mul_B_col_J!(Y::AbstractMatrix, P::HierarchicalPlan, X::AbstractMatrix) = A_mul_B_col_J!!(Y, P, copy(X), J)
 
 function scale_col_J!(b::AbstractVector, A::AbstractVecOrMat, J::Int)
@@ -154,24 +154,24 @@ function getindex(P::ChebyshevToLegendrePlan, i::Int, j::Int)
     end
 end
 
-function A_mul_B!(y::Vector, P::LegendreToChebyshevPlan, x::AbstractVector)
-    HierarchicalMatrices.A_mul_B!(y, P.even, x, 1, 1, 2, 2)
-    HierarchicalMatrices.A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
+function Base.A_mul_B!(y::Vector, P::LegendreToChebyshevPlan, x::AbstractVector)
+    A_mul_B!(y, P.even, x, 1, 1, 2, 2)
+    A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
     scale!(2/π, y)
     y[1] *= 0.5
     y
 end
 
-function A_mul_B!(y::Vector, P::ChebyshevToLegendrePlan, x::AbstractVector)
-    HierarchicalMatrices.A_mul_B!(y, P.even, x, 1, 1, 2, 2)
-    HierarchicalMatrices.A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
+function Base.A_mul_B!(y::Vector, P::ChebyshevToLegendrePlan, x::AbstractVector)
+    A_mul_B!(y, P.even, x, 1, 1, 2, 2)
+    A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
 end
 
-function A_mul_B!(Y::Matrix, P::LegendreToChebyshevPlan, X::Matrix)
+function Base.A_mul_B!(Y::Matrix, P::LegendreToChebyshevPlan, X::Matrix)
     m, n = size(X)
     for j = 1:n
-        HierarchicalMatrices.A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
-        HierarchicalMatrices.A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
     end
     scale!(2/π, Y)
     for j = 1:n
@@ -180,11 +180,11 @@ function A_mul_B!(Y::Matrix, P::LegendreToChebyshevPlan, X::Matrix)
     Y
 end
 
-function A_mul_B!(Y::Matrix, P::ChebyshevToLegendrePlan, X::Matrix)
+function Base.A_mul_B!(Y::Matrix, P::ChebyshevToLegendrePlan, X::Matrix)
     m, n = size(X)
     for j = 1:n
-        HierarchicalMatrices.A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
-        HierarchicalMatrices.A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
     end
     Y
 end
@@ -258,16 +258,16 @@ end
 
 function A_mul_B!!(y::Vector, P::NormalizedLegendreToChebyshevPlan, x::AbstractVector)
     unsafe_broadcasttimes!(x, P.scl)
-    HierarchicalMatrices.A_mul_B!(y, P.even, x, 1, 1, 2, 2)
-    HierarchicalMatrices.A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
+    A_mul_B!(y, P.even, x, 1, 1, 2, 2)
+    A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
     scale!(2/π, y)
     y[1] *= 0.5
     y
 end
 
-function A_mul_B!(y::Vector, P::ChebyshevToNormalizedLegendrePlan, x::AbstractVector)
-    HierarchicalMatrices.A_mul_B!(y, P.even, x, 1, 1, 2, 2)
-    HierarchicalMatrices.A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
+function Base.A_mul_B!(y::Vector, P::ChebyshevToNormalizedLegendrePlan, x::AbstractVector)
+    A_mul_B!(y, P.even, x, 1, 1, 2, 2)
+    A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
     unsafe_broadcasttimes!(y, P.scl)
 end
 
@@ -275,8 +275,8 @@ function A_mul_B!!(Y::Matrix, P::NormalizedLegendreToChebyshevPlan, X::Matrix)
     m, n = size(X)
     scale!(P.scl, X)
     for j = 1:n
-        HierarchicalMatrices.A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
-        HierarchicalMatrices.A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
     end
     scale!(2/π, Y)
     @inbounds @simd for j = 1:n
@@ -285,11 +285,11 @@ function A_mul_B!!(Y::Matrix, P::NormalizedLegendreToChebyshevPlan, X::Matrix)
     Y
 end
 
-function A_mul_B!(Y::Matrix, P::ChebyshevToNormalizedLegendrePlan, X::Matrix)
+function Base.A_mul_B!(Y::Matrix, P::ChebyshevToNormalizedLegendrePlan, X::Matrix)
     m, n = size(X)
     for j = 1:n
-        HierarchicalMatrices.A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
-        HierarchicalMatrices.A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
     end
     scale!(P.scl, Y)
 end
@@ -298,8 +298,8 @@ function A_mul_B_col_J!!(Y::Matrix, P::NormalizedLegendreToChebyshevPlan, X::Mat
     m, n = size(X)
     COLSHIFT = m*(J-1)
     scale_col_J!(P.scl, X, J)
-    HierarchicalMatrices.A_mul_B!(Y, P.even, X, 1+COLSHIFT, 1+COLSHIFT, 2, 2)
-    HierarchicalMatrices.A_mul_B!(Y, P.odd, X, 2+COLSHIFT, 2+COLSHIFT, 2, 2)
+    A_mul_B!(Y, P.even, X, 1+COLSHIFT, 1+COLSHIFT, 2, 2)
+    A_mul_B!(Y, P.odd, X, 2+COLSHIFT, 2+COLSHIFT, 2, 2)
     scale_col_J!(2/π, Y, J)
     @inbounds Y[1+COLSHIFT] *= 0.5
     Y
@@ -308,8 +308,8 @@ end
 function A_mul_B_col_J!(Y::Matrix, P::ChebyshevToNormalizedLegendrePlan, X::Matrix, J::Int)
     m, n = size(X)
     COLSHIFT = m*(J-1)
-    HierarchicalMatrices.A_mul_B!(Y, P.even, X, 1+COLSHIFT, 1+COLSHIFT, 2, 2)
-    HierarchicalMatrices.A_mul_B!(Y, P.odd, X, 2+COLSHIFT, 2+COLSHIFT, 2, 2)
+    A_mul_B!(Y, P.even, X, 1+COLSHIFT, 1+COLSHIFT, 2, 2)
+    A_mul_B!(Y, P.odd, X, 2+COLSHIFT, 2+COLSHIFT, 2, 2)
     scale_col_J!(P.scl, Y, J)
 end
 
@@ -366,13 +366,13 @@ end
 
 function A_mul_B!!(y::Vector, P::NormalizedLegendre1ToChebyshev2Plan, x::AbstractVector)
     unsafe_broadcasttimes!(x, P.scl)
-    HierarchicalMatrices.A_mul_B!(y, P.even, x, 1, 1, 2, 2)
-    HierarchicalMatrices.A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
+    A_mul_B!(y, P.even, x, 1, 1, 2, 2)
+    A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
 end
 
-function A_mul_B!(y::Vector, P::Chebyshev2ToNormalizedLegendre1Plan, x::AbstractVector)
-    HierarchicalMatrices.A_mul_B!(y, P.even, x, 1, 1, 2, 2)
-    HierarchicalMatrices.A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
+function Base.A_mul_B!(y::Vector, P::Chebyshev2ToNormalizedLegendre1Plan, x::AbstractVector)
+    A_mul_B!(y, P.even, x, 1, 1, 2, 2)
+    A_mul_B!(y, P.odd, x, 2, 2, 2, 2)
     unsafe_broadcasttimes!(y, P.scl)
 end
 
@@ -380,17 +380,17 @@ function A_mul_B!!(Y::Matrix, P::NormalizedLegendre1ToChebyshev2Plan, X::Matrix)
     m, n = size(X)
     scale!(P.scl, X)
     for j = 1:n
-        HierarchicalMatrices.A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
-        HierarchicalMatrices.A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
     end
     Y
 end
 
-function A_mul_B!(Y::Matrix, P::Chebyshev2ToNormalizedLegendre1Plan, X::Matrix)
+function Base.A_mul_B!(Y::Matrix, P::Chebyshev2ToNormalizedLegendre1Plan, X::Matrix)
     m, n = size(X)
     for j = 1:n
-        HierarchicalMatrices.A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
-        HierarchicalMatrices.A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.even, X, 1+m*(j-1), 1+m*(j-1), 2, 2)
+        A_mul_B!(Y, P.odd, X, 2+m*(j-1), 2+m*(j-1), 2, 2)
     end
     scale!(P.scl, Y)
 end
@@ -399,16 +399,16 @@ function A_mul_B_col_J!!(Y::Matrix, P::NormalizedLegendre1ToChebyshev2Plan, X::M
     m, n = size(X)
     COLSHIFT = m*(J-1)
     scale_col_J!(P.scl, X, J)
-    HierarchicalMatrices.A_mul_B!(Y, P.even, X, 1+COLSHIFT, 1+COLSHIFT, 2, 2)
-    HierarchicalMatrices.A_mul_B!(Y, P.odd, X, 2+COLSHIFT, 2+COLSHIFT, 2, 2)
+    A_mul_B!(Y, P.even, X, 1+COLSHIFT, 1+COLSHIFT, 2, 2)
+    A_mul_B!(Y, P.odd, X, 2+COLSHIFT, 2+COLSHIFT, 2, 2)
     Y
 end
 
 function A_mul_B_col_J!(Y::Matrix, P::Chebyshev2ToNormalizedLegendre1Plan, X::Matrix, J::Int)
     m, n = size(X)
     COLSHIFT = m*(J-1)
-    HierarchicalMatrices.A_mul_B!(Y, P.even, X, 1+COLSHIFT, 1+COLSHIFT, 2, 2)
-    HierarchicalMatrices.A_mul_B!(Y, P.odd, X, 2+COLSHIFT, 2+COLSHIFT, 2, 2)
+    A_mul_B!(Y, P.even, X, 1+COLSHIFT, 1+COLSHIFT, 2, 2)
+    A_mul_B!(Y, P.odd, X, 2+COLSHIFT, 2+COLSHIFT, 2, 2)
     scale_col_J!(P.scl, Y, J)
 end
 

--- a/src/toeplitzhankel.jl
+++ b/src/toeplitzhankel.jl
@@ -156,13 +156,13 @@ function jac2jacTH{S}(::Type{S},n,α,β,γ,δ)
     T,H,DL,DR
 end
 
-immutable ChebyshevToLegendrePlan{TH}
+immutable ChebyshevToLegendrePlanTH{TH}
     toeplitzhankel::TH
 end
 
-ChebyshevToLegendrePlan{S}(::Type{S},n) = ChebyshevToLegendrePlan(th_cheb2legplan(S,n))
+ChebyshevToLegendrePlanTH{S}(::Type{S},n) = ChebyshevToLegendrePlanTH(th_cheb2legplan(S,n))
 
-function *(P::ChebyshevToLegendrePlan,v::AbstractVector)
+function *(P::ChebyshevToLegendrePlanTH,v::AbstractVector)
     w = zero(v)
     S,n = eltype(v),length(v)
     w[1:2:end] = -one(S)./(one(S):two(S):n)./(-one(S):two(S):n-two(S))
@@ -170,7 +170,7 @@ function *(P::ChebyshevToLegendrePlan,v::AbstractVector)
 end
 
 th_leg2chebplan{S}(::Type{S},n)=ToeplitzHankelPlan(leg2chebTH(S,n)...,ones(S,n))
-th_cheb2legplan{S}(::Type{S},n)=ChebyshevToLegendrePlan(ToeplitzHankelPlan(cheb2legTH(S,n)...))
+th_cheb2legplan{S}(::Type{S},n)=ChebyshevToLegendrePlanTH(ToeplitzHankelPlan(cheb2legTH(S,n)...))
 th_leg2chebuplan{S}(::Type{S},n)=ToeplitzHankelPlan(leg2chebuTH(S,n)...,1:n,ones(S,n))
 th_ultra2ultraplan{S}(::Type{S},n,λ₁,λ₂)=ToeplitzHankelPlan(ultra2ultraTH(S,n,λ₁,λ₂)...)
 th_jac2jacplan{S}(::Type{S},n,α,β,γ,δ)=ToeplitzHankelPlan(jac2jacTH(S,n,α,β,γ,δ)...)

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -1,7 +1,9 @@
 using FastTransforms, LowRankApprox
 using Base.Test
 
+println()
 println("A_mul_B!, At_mul_B!, and Ac_mul_B!")
+println()
 
 for T in (Float64, Complex128)
     r = rand(T)
@@ -12,13 +14,13 @@ for T in (Float64, Complex128)
     x = rand(T, n)
     y = zeros(T, k)
 
-    @test A_mul_B!(y, A, P, x, 1, 1) == A*x
+    @test FastTransforms.A_mul_B!(y, A, P, x, 1, 1) == A*x
 
     x = rand(T, k)
     y = zeros(T, n)
 
-    @test norm(At_mul_B!(y, A, P, x, 1, 1) - A.'x,Inf) < 10eps()
+    @test norm(FastTransforms.At_mul_B!(y, A, P, x, 1, 1) - A.'x, Inf) < 10eps()
 
     fill!(y, zero(T))
-    @test norm(Ac_mul_B!(y, A, P, x, 1, 1) - A'x,Inf) < 10eps()
+    @test norm(FastTransforms.Ac_mul_B!(y, A, P, x, 1, 1) - A'x, Inf) < 10eps()
 end

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -1,0 +1,24 @@
+using FastTransforms, LowRankApprox
+using Base.Test
+
+println("A_mul_B!, At_mul_B!, and Ac_mul_B!")
+
+for T in (Float64, Complex128)
+    r = rand(T)
+    A = idfact([r/(i+j-1) for i in 1:200, j = 1:50])
+    P = A[:P]
+    k, n = size(A)
+
+    x = rand(T, n)
+    y = zeros(T, k)
+
+    @test A_mul_B!(y, A, P, x, 1, 1) == A*x
+
+    x = rand(T, k)
+    y = zeros(T, n)
+
+    @test norm(At_mul_B!(y, A, P, x, 1, 1) - A.'x,Inf) < 10eps()
+
+    fill!(y, zero(T))
+    @test norm(Ac_mul_B!(y, A, P, x, 1, 1) - A'x,Inf) < 10eps()
+end

--- a/test/butterflytests.jl
+++ b/test/butterflytests.jl
@@ -1,7 +1,9 @@
 using FastTransforms, LowRankApprox
 using Base.Test
 
+println()
 println("Butterfly algorithm tests")
+println()
 
 import FastTransforms: Butterfly
 

--- a/test/butterflytests.jl
+++ b/test/butterflytests.jl
@@ -1,0 +1,57 @@
+using FastTransforms, LowRankApprox
+using Base.Test
+
+import FastTransforms: Butterfly
+
+kernel = (x,y) -> exp(im*x*y)
+
+function randfft(m,n,σ)
+    x = (linspace(0,m-1,m)+σ*rand(m))
+    y = (linspace(0,n-1,n)+σ*rand(n))*2π/n
+    Complex{Float64}[kernel(x,y) for x in x, y in y]
+end
+
+function randnfft(m,n,σ)
+    x = (linspace(0,m-1,m)+σ*randn(m))
+    y = (linspace(0,n-1,n)+σ*randn(n))*2π/n
+    Complex{Float64}[kernel(x,y) for x in x, y in y]
+end
+
+N = 10
+A = Vector{Matrix{Complex{Float64}}}(N)
+for n in 1:N
+    A[n] = randnfft(2^n,2^n,0.0)
+    println(n)
+end
+
+for n in 7:N
+    println("N = ", n)
+    @time B = Butterfly(A[n], n-5)
+    b = rand(Complex{Float64},2^n)./(1:2^n)
+    u = zero(b)
+    @time uf = A[n]*b
+    @time A_mul_B!(u, B, b)
+    w = zero(b)
+    @time Ac_mul_B!(w, B, u)
+    scale!(inv(2^n), w)
+    println(norm(u-uf)/2^n)
+    println(norm(w-b))
+    println(norm(w-A[n]\u))
+end
+
+N = 10
+A = Vector{Matrix{Complex{Float64}}}(N)
+for n in 1:N
+    A[n] = randnfft(2^n,2^n,0.1)
+    println(n)
+end
+
+for n in 7:N
+    println("N = ", n)
+    @time B = Butterfly(A[n], n-5)
+    b = rand(Complex{Float64},2^n)./(1:2^n)
+    u = zero(b)
+    @time uf = A[n]*b
+    @time A_mul_B!(u, B, b)
+    println(norm(u-uf)/2^n)
+end

--- a/test/butterflytests.jl
+++ b/test/butterflytests.jl
@@ -79,7 +79,7 @@ for n in 7:N
 end
 
 
-N = 14
+N = 12
 A = Vector{Matrix{Complex{Float64}}}(N)
 B = Vector{Butterfly{Complex{Float64}}}(N)
 for n in 7:N

--- a/test/butterflytests.jl
+++ b/test/butterflytests.jl
@@ -1,6 +1,8 @@
 using FastTransforms, LowRankApprox
 using Base.Test
 
+println("Butterfly algorithm tests")
+
 import FastTransforms: Butterfly
 
 kernel = (x,y) -> exp(im*x*y)
@@ -60,26 +62,7 @@ for n in 7:N
     println(norm(u-w))
 end
 
-
 N = 10
-A = Vector{Matrix{Complex{Float64}}}(N)
-for n in 1:N
-    A[n] = randnfft(2^n,2^n,0.1)
-    println(n)
-end
-
-for n in 7:N
-    println("N = ", n)
-    @time B = Butterfly(A[n], n-5)
-    b = rand(Complex{Float64},2^n)./(1:2^n)
-    u = zero(b)
-    @time uf = A[n]*b
-    @time A_mul_B!(u, B, b)
-    println(norm(u-uf)/2^n)
-end
-
-
-N = 12
 A = Vector{Matrix{Complex{Float64}}}(N)
 B = Vector{Butterfly{Complex{Float64}}}(N)
 for n in 7:N
@@ -93,10 +76,7 @@ for n in 7:N
     b = rand(Complex{Float64},2^n)./(1:2^n)
     uf = zero(b)
     u = zero(b)
-    @time for k = 1:100
-        A_mul_B!(uf, A[n], b)
-    end
-    @time for k = 1:100
-        A_mul_B!(u, B[n], b)
-    end
+    @time A_mul_B!(uf, A[n], b)
+    @time A_mul_B!(u, B[n], b)
+    println(norm(u-uf))
 end

--- a/test/butterflytests.jl
+++ b/test/butterflytests.jl
@@ -77,3 +77,26 @@ for n in 7:N
     @time A_mul_B!(u, B, b)
     println(norm(u-uf)/2^n)
 end
+
+
+N = 14
+A = Vector{Matrix{Complex{Float64}}}(N)
+B = Vector{Butterfly{Complex{Float64}}}(N)
+for n in 7:N
+    A[n] = randnfft(2^n,2^n,0.1)
+    @time B[n] = Butterfly(A[n], n-6)
+    println(n)
+end
+
+for n in 7:N
+    println("N = ", n)
+    b = rand(Complex{Float64},2^n)./(1:2^n)
+    uf = zero(b)
+    u = zero(b)
+    @time for k = 1:100
+        A_mul_B!(uf, A[n], b)
+    end
+    @time for k = 1:100
+        A_mul_B!(u, B[n], b)
+    end
+end

--- a/test/butterflytests.jl
+++ b/test/butterflytests.jl
@@ -40,6 +40,28 @@ for n in 7:N
 end
 
 N = 10
+A = Vector{Matrix{Float64}}(N)
+for n in 1:N
+    A[n] = Float64[1/(i+j-1) for i = 1:2^n,j=1:2^n]
+    println(n)
+end
+
+for n in 7:N
+    println("N = ", n)
+    @time B = Butterfly(A[n], n-5)
+    b = rand(Float64,2^n)./(1:2^n)
+    u = zero(b)
+    @time uf = A[n]*b
+    @time A_mul_B!(u, B, b)
+    w = zero(b)
+    @time At_mul_B!(w, B, b)
+    println(norm(u-uf)/2^n)
+    println(norm(w-A[n]'b))
+    println(norm(u-w))
+end
+
+
+N = 10
 A = Vector{Matrix{Complex{Float64}}}(N)
 for n in 1:N
     A[n] = randnfft(2^n,2^n,0.1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using FastTransforms
 using Base.Test
 
+srand(0)
+
 println("Testing special functions")
 n = 0:1000_000
 λ = 0.123
@@ -265,3 +267,9 @@ f_m=paduaeval(f_xy,x,y,m,Val{false})
 g_l=paduaeval(g_xy,x,y,l,Val{false})
 @test f_xy(x,y) ≈ f_m
 @test g_xy(x,y) ≈ g_l
+
+include("basictests.jl")
+
+include("butterflytests.jl")
+
+include("sphericalharmonictests.jl")

--- a/test/sphericalharmonictestfunctions.jl
+++ b/test/sphericalharmonictestfunctions.jl
@@ -1,0 +1,78 @@
+function sphrand{T}(::Type{T}, m, n)
+    A = zeros(T, m, 2n-1)
+    for i = 1:m
+        A[i,1] = rand(T)
+    end
+    for j = 1:n
+        for i = 1:m-j
+            A[i,2j] = rand(T)
+            A[i,2j+1] = rand(T)
+        end
+    end
+    A
+end
+
+function sphrandn{T}(::Type{T}, m, n)
+    A = zeros(T, m, 2n-1)
+    for i = 1:m
+        A[i,1] = randn(T)
+    end
+    for j = 1:n
+        for i = 1:m-j
+            A[i,2j] = randn(T)
+            A[i,2j+1] = randn(T)
+        end
+    end
+    A
+end
+
+function normalizecolumns!(A::AbstractMatrix)
+    m, n = size(A)
+    @inbounds for j = 1:n
+        nrm = zero(eltype(A))
+        for i = 1:m
+            nrm += abs2(A[i,j])
+        end
+        nrm = sqrt(nrm)
+        for i = 1:m
+            A[i,j] /= nrm
+        end
+    end
+    A
+end
+
+function maxcolnorm(A::AbstractMatrix)
+    m, n = size(A)
+    nrm = zeros(n)
+    @inbounds for j = 1:n
+        nrm[j] = 0
+        for i = 1:m
+            nrm[j] += abs2(A[i,j])
+        end
+        nrm[j] = sqrt(nrm[j])
+    end
+    norm(nrm, Inf)
+end
+
+function sphevaluatepi(θ::Number,L::Integer,M::Integer)
+    ret = one(θ)/sqrt(two(θ))
+    if M < 0 M = -M end
+    c, s = cospi(θ), sinpi(θ)
+    for m = 1:M
+        ret *= sqrt((m+half(θ))/m)*s
+    end
+    tc = two(c)*c
+
+    if L == M
+        return ret
+    elseif L == M+1
+        return sqrt(two(θ)*M+3)*c*ret
+    else
+        temp = ret
+        ret *= sqrt(two(θ)*M+3)*c
+        for l = M+1:L-1
+            ret, temp = (sqrt(l+half(θ))*tc*ret - sqrt((l-M)*(l+M)/(l-half(θ)))*temp)/sqrt((l-M+1)*(l+M+1)/(l+3half(θ))), ret
+        end
+        return ret
+    end
+end

--- a/test/sphericalharmonictests.jl
+++ b/test/sphericalharmonictests.jl
@@ -1,5 +1,7 @@
 using FastTransforms, Base.Test
 
+srand(0)
+
 include("sphericalharmonictestfunctions.jl")
 
 println("Testing slow plan")
@@ -8,3 +10,33 @@ println("Testing fast plan")
 include("test_fastplan.jl")
 println("Testing thin plan")
 include("test_thinplan.jl")
+
+println("Testing API")
+
+n = 511
+A = sphrandn(Float64, n+1, n+1);
+normalizecolumns!(A);
+
+B = sph2fourier(A; sketch = :none)
+C = fourier2sph(B; sketch = :none)
+println("The backward difference between slow plan and original: ", maxcolnorm(A-C))
+
+P = plan_sph2fourier(A; sketch = :none)
+B = P*A
+C = P\B
+
+println("The backward difference between slow plan and original: ", maxcolnorm(A-C))
+
+n = 1023
+A = sphrandn(Float64, n+1, n+1);
+normalizecolumns!(A);
+
+B = sph2fourier(A; sketch = :none)
+C = fourier2sph(B; sketch = :none)
+println("The backward difference between slow plan and original: ", maxcolnorm(A-C))
+
+P = plan_sph2fourier(A; sketch = :none)
+B = P*A
+C = P\B
+
+println("The backward difference between thin plan and original: ", maxcolnorm(A-C))

--- a/test/sphericalharmonictests.jl
+++ b/test/sphericalharmonictests.jl
@@ -1,60 +1,6 @@
 using FastTransforms, Base.Test
 
-function sphrand{T}(::Type{T}, m, n)
-    A = zeros(T, m, 2n-1)
-    for i = 1:m
-        A[i,1] = rand(T)
-    end
-    for j = 1:n
-        for i = 1:m-j
-            A[i,2j] = rand(T)
-            A[i,2j+1] = rand(T)
-        end
-    end
-    A
-end
-
-function sphrandn{T}(::Type{T}, m, n)
-    A = zeros(T, m, 2n-1)
-    for i = 1:m
-        A[i,1] = randn(T)
-    end
-    for j = 1:n
-        for i = 1:m-j
-            A[i,2j] = randn(T)
-            A[i,2j+1] = randn(T)
-        end
-    end
-    A
-end
-
-function normalizecolumns!(A::AbstractMatrix)
-    m, n = size(A)
-    @inbounds for j = 1:n
-        nrm = zero(eltype(A))
-        for i = 1:m
-            nrm += abs2(A[i,j])
-        end
-        nrm = sqrt(nrm)
-        for i = 1:m
-            A[i,j] /= nrm
-        end
-    end
-    A
-end
-
-function maxcolnorm(A::AbstractMatrix)
-    m, n = size(A)
-    nrm = zeros(n)
-    @inbounds for j = 1:n
-        nrm[j] = 0
-        for i = 1:m
-            nrm[j] += abs2(A[i,j])
-        end
-        nrm[j] = sqrt(nrm[j])
-    end
-    norm(nrm, Inf)
-end
+include("sphericalharmonictestfunctions.jl")
 
 println("Testing slow plan")
 include("test_slowplan.jl")

--- a/test/sphericalharmonictests.jl
+++ b/test/sphericalharmonictests.jl
@@ -60,7 +60,7 @@ println()
 
 import FastTransforms: normalizecolumns!, maxcolnorm
 
-n = 511
+n = VERSION < v"0.6.0-" ? 255 : 511
 A = sphrandn(Float64, n+1, n+1);
 normalizecolumns!(A);
 
@@ -74,16 +74,18 @@ C = P\B
 
 println("The backward difference between slow plan and original: ", maxcolnorm(A-C))
 
-n = 1023
-A = sphrandn(Float64, n+1, n+1);
-normalizecolumns!(A);
+if VERSION ≥ v"0.6.0-"
+    n = 1023
+    A = sphrandn(Float64, n+1, n+1);
+    normalizecolumns!(A);
 
-B = sph2fourier(A; sketch = :none)
-C = fourier2sph(B; sketch = :none)
-println("The backward difference between thin plan and original: ", maxcolnorm(A-C))
+    B = sph2fourier(A; sketch = :none)
+    C = fourier2sph(B; sketch = :none)
+    println("The backward difference between thin plan and original: ", maxcolnorm(A-C))
 
-P = plan_sph2fourier(A; sketch = :none)
-B = P*A
-C = P\B
+    P = plan_sph2fourier(A; sketch = :none)
+    B = P*A
+    C = P\B
 
-println("The backward difference between thin plan and original: ", maxcolnorm(A-C))
+    println("The backward difference between thin plan and original: ", maxcolnorm(A-C))
+end

--- a/test/sphericalharmonictests.jl
+++ b/test/sphericalharmonictests.jl
@@ -1,0 +1,64 @@
+using FastTransforms, Base.Test
+
+function sphrand{T}(::Type{T}, m, n)
+    A = zeros(T, m, 2n-1)
+    for i = 1:m
+        A[i,1] = rand(T)
+    end
+    for j = 1:n
+        for i = 1:m-j
+            A[i,2j] = rand(T)
+            A[i,2j+1] = rand(T)
+        end
+    end
+    A
+end
+
+function sphrandn{T}(::Type{T}, m, n)
+    A = zeros(T, m, 2n-1)
+    for i = 1:m
+        A[i,1] = randn(T)
+    end
+    for j = 1:n
+        for i = 1:m-j
+            A[i,2j] = randn(T)
+            A[i,2j+1] = randn(T)
+        end
+    end
+    A
+end
+
+function normalizecolumns!(A::AbstractMatrix)
+    m, n = size(A)
+    @inbounds for j = 1:n
+        nrm = zero(eltype(A))
+        for i = 1:m
+            nrm += abs2(A[i,j])
+        end
+        nrm = sqrt(nrm)
+        for i = 1:m
+            A[i,j] /= nrm
+        end
+    end
+    A
+end
+
+function maxcolnorm(A::AbstractMatrix)
+    m, n = size(A)
+    nrm = zeros(n)
+    @inbounds for j = 1:n
+        nrm[j] = 0
+        for i = 1:m
+            nrm[j] += abs2(A[i,j])
+        end
+        nrm[j] = sqrt(nrm[j])
+    end
+    norm(nrm, Inf)
+end
+
+println("Testing slow plan")
+include("test_slowplan.jl")
+println("Testing fast plan")
+include("test_fastplan.jl")
+println("Testing thin plan")
+include("test_thinplan.jl")

--- a/test/sphericalharmonictests.jl
+++ b/test/sphericalharmonictests.jl
@@ -35,7 +35,6 @@ for θ in (0.123, 0.456)
     S0 = sum(cospi((ℓ-1)*θ)*B[ℓ,1] for ℓ in 1:n+1)
     SA = sum(sphevaluatepi(θ,ℓ-1,0)*A[ℓ,1] for ℓ in 1:n+1)
     @test norm(S0-SA) < 1000eps()
-    push!(nrms, norm(S0-SA))
     for m in 3:2:n+1
         S0 = sum(cospi((ℓ-1)*θ)*B[ℓ,2m-2] for ℓ in 1:n+1)
         SA = sum(sphevaluatepi(θ,ℓ+m-2,m-1)*A[ℓ,2m-2] for ℓ in 1:n+1)

--- a/test/test_fastplan.jl
+++ b/test/test_fastplan.jl
@@ -1,6 +1,6 @@
 import FastTransforms: allranks
 
-n = 255
+n = 511
 
 A = sphrandn(Float64, n+1, n+1);
 normalizecolumns!(A);

--- a/test/test_fastplan.jl
+++ b/test/test_fastplan.jl
@@ -1,111 +1,23 @@
-using FastTransforms
-
-import FastTransforms: RotationPlan, SlowSphericalHarmonicPlan, FastSphericalHarmonicPlan
 import FastTransforms: allranks
-
-function sphrand{T}(::Type{T}, m, n)
-    A = zeros(T, m, 2n-1)
-    for i = 1:m
-        A[i,1] = rand(T)
-    end
-    for j = 1:n
-        for i = 1:m-j
-            A[i,2j] = rand(T)
-            A[i,2j+1] = rand(T)
-        end
-    end
-    A
-end
-
-function sphrandn{T}(::Type{T}, m, n)
-    A = zeros(T, m, 2n-1)
-    for i = 1:m
-        A[i,1] = randn(T)
-    end
-    for j = 1:n
-        for i = 1:m-j
-            A[i,2j] = randn(T)
-            A[i,2j+1] = randn(T)
-        end
-    end
-    A
-end
-
-function normalizecolumns!(A::AbstractMatrix)
-    m, n = size(A)
-    @inbounds for j = 1:n
-        nrm = zero(eltype(A))
-        for i = 1:m
-            nrm += abs2(A[i,j])
-        end
-        nrm = sqrt(nrm)
-        for i = 1:m
-            A[i,j] /= nrm
-        end
-    end
-    A
-end
-
-function maxcolnorm(A::AbstractMatrix)
-    m, n = size(A)
-    nrm = zeros(n)
-    @inbounds for j = 1:n
-        nrm[n] = 0
-        for i = 1:m
-            nrm[n] += abs2(A[i,j])
-        end
-        nrm[n] = sqrt(nrm[n])
-    end
-    norm(nrm, Inf)
-end
-
-function zero_spurious_modes!(A::AbstractMatrix)
-    M, N = size(A)
-    n = N÷2
-    for j = 1:n
-        for i = M-j+1:M
-            A[i,2j] = 0
-            A[i,2j+1] = 0
-        end
-    end
-    A
-end
 
 n = 255
 
-A = sphrandn(Float64, n+1, n+1)
-normalizecolumns!(A)
-Ac = deepcopy(A)
-
-FP = FastSphericalHarmonicPlan(A, 2);
-
+A = sphrandn(Float64, n+1, n+1);
+normalizecolumns!(A);
 B = zero(A);
-
-@time A_mul_B!(B, FP, A);
-
-SP = SlowSphericalHarmonicPlan(A);
-
 C = zero(A);
-
-@time A_mul_B!(C, SP, A);
-
-println("The difference between slow and fast plans: ", maxcolnorm(B-C))
-
 D = zero(A);
-
-@time At_mul_B!(D, FP, B);
-
 E = zero(A);
 
-@time At_mul_B!(E, SP, C);
+@time FP = FastSphericalHarmonicPlan(A);
+@time SP = SlowSphericalHarmonicPlan(A);
 
-println("The difference between fast plan and original: ", maxcolnorm(A-D))
-println("The difference between slow plan and original: ", maxcolnorm(A-E))
-println("The difference between slow and fast plans: ", maxcolnorm(D-E))
+@time A_mul_B!(B, SP, A);
+@time A_mul_B!(C, FP, A);
+@time At_mul_B!(D, SP, B);
+@time At_mul_B!(E, FP, C);
 
-zero_spurious_modes!(D);
-zero_spurious_modes!(E);
-
-println("The difference between fast plan and original: ", maxcolnorm(A-D))
-println("The difference between slow plan and original: ", maxcolnorm(A-E))
-println("The difference between slow and fast plans: ", maxcolnorm(D-E))
+println("The forward difference between slow and fast plans: ", maxcolnorm(B-C))
+println("The backward difference between slow plan and original: ", maxcolnorm(A-D))
+println("The backward difference between fast plan and original: ", maxcolnorm(A-E))
+println("The backward difference between slow and fast plans: ", maxcolnorm(D-E))

--- a/test/test_fastplan.jl
+++ b/test/test_fastplan.jl
@@ -1,4 +1,4 @@
-import FastTransforms: allranks
+import FastTransforms: allranks, normalizecolumns!, maxcolnorm
 
 n = 511
 

--- a/test/test_fastplan.jl
+++ b/test/test_fastplan.jl
@@ -59,13 +59,25 @@ function maxcolnorm(A::AbstractMatrix)
     norm(nrm, Inf)
 end
 
-n = 1023
+function zero_spurious_modes!(A::AbstractMatrix)
+    M, N = size(A)
+    n = N÷2
+    for j = 1:n
+        for i = M-j+1:M
+            A[i,2j] = 0
+            A[i,2j+1] = 0
+        end
+    end
+    A
+end
+
+n = 255
 
 A = sphrandn(Float64, n+1, n+1)
 normalizecolumns!(A)
 Ac = deepcopy(A)
 
-FP = FastSphericalHarmonicPlan(A, 5);
+FP = FastSphericalHarmonicPlan(A, 2);
 
 B = zero(A);
 
@@ -91,20 +103,8 @@ println("The difference between fast plan and original: ", maxcolnorm(A-D))
 println("The difference between slow plan and original: ", maxcolnorm(A-E))
 println("The difference between slow and fast plans: ", maxcolnorm(D-E))
 
-function zero_spurious_modes!(A::AbstractMatrix)
-    M, N = size(A)
-    n = N÷2
-    for j = 1:n
-        for i = M-j+1:M
-            A[i,2j] = 0
-            A[i,2j+1] = 0
-        end
-    end
-    A
-end
-
-zero_spurious_modes!(D)
-zero_spurious_modes!(E)
+zero_spurious_modes!(D);
+zero_spurious_modes!(E);
 
 println("The difference between fast plan and original: ", maxcolnorm(A-D))
 println("The difference between slow plan and original: ", maxcolnorm(A-E))

--- a/test/test_fastplan.jl
+++ b/test/test_fastplan.jl
@@ -1,0 +1,111 @@
+using FastTransforms
+
+import FastTransforms: RotationPlan, SlowSphericalHarmonicPlan, FastSphericalHarmonicPlan
+import FastTransforms: allranks
+
+function sphrand{T}(::Type{T}, m, n)
+    A = zeros(T, m, 2n-1)
+    for i = 1:m
+        A[i,1] = rand(T)
+    end
+    for j = 1:n
+        for i = 1:m-j
+            A[i,2j] = rand(T)
+            A[i,2j+1] = rand(T)
+        end
+    end
+    A
+end
+
+function sphrandn{T}(::Type{T}, m, n)
+    A = zeros(T, m, 2n-1)
+    for i = 1:m
+        A[i,1] = randn(T)
+    end
+    for j = 1:n
+        for i = 1:m-j
+            A[i,2j] = randn(T)
+            A[i,2j+1] = randn(T)
+        end
+    end
+    A
+end
+
+function normalizecolumns!(A::AbstractMatrix)
+    m, n = size(A)
+    @inbounds for j = 1:n
+        nrm = zero(eltype(A))
+        for i = 1:m
+            nrm += abs2(A[i,j])
+        end
+        nrm = sqrt(nrm)
+        for i = 1:m
+            A[i,j] /= nrm
+        end
+    end
+    A
+end
+
+function maxcolnorm(A::AbstractMatrix)
+    m, n = size(A)
+    nrm = zeros(n)
+    @inbounds for j = 1:n
+        nrm[n] = 0
+        for i = 1:m
+            nrm[n] += abs2(A[i,j])
+        end
+        nrm[n] = sqrt(nrm[n])
+    end
+    norm(nrm, Inf)
+end
+
+n = 1023
+
+A = sphrandn(Float64, n+1, n+1)
+normalizecolumns!(A)
+Ac = deepcopy(A)
+
+FP = FastSphericalHarmonicPlan(A, 5);
+
+B = zero(A);
+
+@time A_mul_B!(B, FP, A);
+
+SP = SlowSphericalHarmonicPlan(A);
+
+C = zero(A);
+
+@time A_mul_B!(C, SP, A);
+
+println("The difference between slow and fast plans: ", maxcolnorm(B-C))
+
+D = zero(A);
+
+@time At_mul_B!(D, FP, B);
+
+E = zero(A);
+
+@time At_mul_B!(E, SP, C);
+
+println("The difference between fast plan and original: ", maxcolnorm(A-D))
+println("The difference between slow plan and original: ", maxcolnorm(A-E))
+println("The difference between slow and fast plans: ", maxcolnorm(D-E))
+
+function zero_spurious_modes!(A::AbstractMatrix)
+    M, N = size(A)
+    n = N÷2
+    for j = 1:n
+        for i = M-j+1:M
+            A[i,2j] = 0
+            A[i,2j+1] = 0
+        end
+    end
+    A
+end
+
+zero_spurious_modes!(D)
+zero_spurious_modes!(E)
+
+println("The difference between fast plan and original: ", maxcolnorm(A-D))
+println("The difference between slow plan and original: ", maxcolnorm(A-E))
+println("The difference between slow and fast plans: ", maxcolnorm(D-E))

--- a/test/test_fastplan.jl
+++ b/test/test_fastplan.jl
@@ -9,7 +9,7 @@ C = zero(A);
 D = zero(A);
 E = zero(A);
 
-@time FP = FastSphericalHarmonicPlan(A);
+@time FP = FastSphericalHarmonicPlan(A; sketch = :none);
 @time SP = SlowSphericalHarmonicPlan(A);
 
 @time A_mul_B!(B, SP, A);

--- a/test/test_fastplan.jl
+++ b/test/test_fastplan.jl
@@ -1,6 +1,6 @@
 import FastTransforms: allranks, normalizecolumns!, maxcolnorm
 
-n = 511
+n = 255
 
 A = sphrandn(Float64, n+1, n+1);
 normalizecolumns!(A);

--- a/test/test_slowplan.jl
+++ b/test/test_slowplan.jl
@@ -1,6 +1,6 @@
 import FastTransforms: normalizecolumns!, maxcolnorm
 
-N = round.(Int,logspace(1,3,20))
+N = round.([Int],logspace(1,3,20))
 
 t = zeros(length(N))
 err = zeros(length(N))

--- a/test/test_slowplan.jl
+++ b/test/test_slowplan.jl
@@ -1,0 +1,84 @@
+using FastTransforms
+
+import FastTransforms: RotationPlan, SlowSphericalHarmonicPlan
+
+function sphrand{T}(::Type{T}, m, n)
+    A = zeros(T, m, 2n-1)
+    for i = 1:m
+        A[i,1] = rand(T)
+    end
+    for j = 1:n
+        for i = 1:m-j
+            A[i,2j] = rand(T)
+            A[i,2j+1] = rand(T)
+        end
+    end
+    A
+end
+
+function sphrandn{T}(::Type{T}, m, n)
+    A = zeros(T, m, 2n-1)
+    for i = 1:m
+        A[i,1] = randn(T)
+    end
+    for j = 1:n
+        for i = 1:m-j
+            A[i,2j] = randn(T)
+            A[i,2j+1] = randn(T)
+        end
+    end
+    A
+end
+
+function normalizecolumns!(A::AbstractMatrix)
+    m, n = size(A)
+    @inbounds for j = 1:n
+        nrm = zero(eltype(A))
+        for i = 1:m
+            nrm += abs2(A[i,j])
+        end
+        nrm = sqrt(nrm)
+        for i = 1:m
+            A[i,j] /= nrm
+        end
+    end
+    A
+end
+
+function maxcolnorm(A::AbstractMatrix)
+    m, n = size(A)
+    nrm = zeros(n)
+    @inbounds for j = 1:n
+        nrm[n] = 0
+        for i = 1:m
+            nrm[n] += abs2(A[i,j])
+        end
+        nrm[n] = sqrt(nrm[n])
+    end
+    norm(nrm, Inf)
+end
+
+N = round.(Int,logspace(1,3,40))
+
+t = zeros(length(N))
+err = zeros(length(N))
+
+Nr = 10
+
+j = 1
+for n in N
+    RP = RotationPlan(Float64, n)
+    nrms = zeros(Nr)
+    for kk = 1:Nr
+        A = sphrandn(Float64, n+1, n+1)
+        normalizecolumns!(A)
+        Ac = deepcopy(A)
+        println("The bandlimit n is: ",n)
+        t[j] += @elapsed At_mul_B!(RP, A_mul_B!(RP, A))
+        nrms[kk] = maxcolnorm(A - Ac)
+    end
+    t[j] /= Nr
+    err[j] = mean(nrms)#norm(nrms,Inf)
+    println("The maximum 2-norm in the columns over 10 trials is: ",err[j])
+    j+=1
+end

--- a/test/test_slowplan.jl
+++ b/test/test_slowplan.jl
@@ -1,3 +1,5 @@
+import FastTransforms: normalizecolumns!, maxcolnorm
+
 N = round.(Int,logspace(1,3,20))
 
 t = zeros(length(N))

--- a/test/test_slowplan.jl
+++ b/test/test_slowplan.jl
@@ -1,11 +1,11 @@
 import FastTransforms: normalizecolumns!, maxcolnorm
 
-N = round.([Int],logspace(1,3,20))
+N = round.([Int],logspace(1,2.5,10))
 
 t = zeros(length(N))
 err = zeros(length(N))
 
-Nr = 3
+Nr = 2
 
 j = 1
 for n in N

--- a/test/test_slowplan.jl
+++ b/test/test_slowplan.jl
@@ -1,4 +1,4 @@
-N = round.(Int,logspace(1,3,40))
+N = round.(Int,logspace(1,3,20))
 
 t = zeros(length(N))
 err = zeros(length(N))
@@ -20,7 +20,7 @@ for n in N
         nrms[kk] = maxcolnorm(A - Ac)
     end
     t[j] /= Nr
-    err[j] = mean(nrms)#norm(nrms,Inf)
+    err[j] = mean(nrms)
     println("At a bandlimit of ",n,", the maximum 2-norm in the columns over ",Nr," trials is: ",err[j])
     j+=1
 end

--- a/test/test_slowplan.jl
+++ b/test/test_slowplan.jl
@@ -1,84 +1,26 @@
-using FastTransforms
-
-import FastTransforms: RotationPlan, SlowSphericalHarmonicPlan
-
-function sphrand{T}(::Type{T}, m, n)
-    A = zeros(T, m, 2n-1)
-    for i = 1:m
-        A[i,1] = rand(T)
-    end
-    for j = 1:n
-        for i = 1:m-j
-            A[i,2j] = rand(T)
-            A[i,2j+1] = rand(T)
-        end
-    end
-    A
-end
-
-function sphrandn{T}(::Type{T}, m, n)
-    A = zeros(T, m, 2n-1)
-    for i = 1:m
-        A[i,1] = randn(T)
-    end
-    for j = 1:n
-        for i = 1:m-j
-            A[i,2j] = randn(T)
-            A[i,2j+1] = randn(T)
-        end
-    end
-    A
-end
-
-function normalizecolumns!(A::AbstractMatrix)
-    m, n = size(A)
-    @inbounds for j = 1:n
-        nrm = zero(eltype(A))
-        for i = 1:m
-            nrm += abs2(A[i,j])
-        end
-        nrm = sqrt(nrm)
-        for i = 1:m
-            A[i,j] /= nrm
-        end
-    end
-    A
-end
-
-function maxcolnorm(A::AbstractMatrix)
-    m, n = size(A)
-    nrm = zeros(n)
-    @inbounds for j = 1:n
-        nrm[n] = 0
-        for i = 1:m
-            nrm[n] += abs2(A[i,j])
-        end
-        nrm[n] = sqrt(nrm[n])
-    end
-    norm(nrm, Inf)
-end
-
 N = round.(Int,logspace(1,3,40))
 
 t = zeros(length(N))
 err = zeros(length(N))
 
-Nr = 10
+Nr = 3
 
 j = 1
 for n in N
-    RP = RotationPlan(Float64, n)
     nrms = zeros(Nr)
     for kk = 1:Nr
         A = sphrandn(Float64, n+1, n+1)
         normalizecolumns!(A)
-        Ac = deepcopy(A)
-        println("The bandlimit n is: ",n)
-        t[j] += @elapsed At_mul_B!(RP, A_mul_B!(RP, A))
+        Ac = copy(A)
+        B = zero(A)
+        SP = SlowSphericalHarmonicPlan(A)
+        A_mul_B!(B, SP, A)
+        fill!(A, 0.0)
+        t[j] += @elapsed At_mul_B!(A, SP, B)
         nrms[kk] = maxcolnorm(A - Ac)
     end
     t[j] /= Nr
     err[j] = mean(nrms)#norm(nrms,Inf)
-    println("The maximum 2-norm in the columns over 10 trials is: ",err[j])
+    println("At a bandlimit of ",n,", the maximum 2-norm in the columns over ",Nr," trials is: ",err[j])
     j+=1
 end

--- a/test/test_thinplan.jl
+++ b/test/test_thinplan.jl
@@ -1,6 +1,6 @@
 import FastTransforms: allranks
 
-n = 255
+n = 511
 
 A = sphrandn(Float64, n+1, n+1);
 normalizecolumns!(A);

--- a/test/test_thinplan.jl
+++ b/test/test_thinplan.jl
@@ -1,0 +1,23 @@
+import FastTransforms: allranks
+
+n = 255
+
+A = sphrandn(Float64, n+1, n+1);
+normalizecolumns!(A);
+B = zero(A);
+C = zero(A);
+D = zero(A);
+E = zero(A);
+
+@time TP = ThinSphericalHarmonicPlan(A);
+@time SP = SlowSphericalHarmonicPlan(A);
+
+@time A_mul_B!(B, SP, A);
+@time A_mul_B!(C, TP, A);
+@time At_mul_B!(D, SP, B);
+@time At_mul_B!(E, TP, C);
+
+println("The forward difference between slow and thin plans: ", maxcolnorm(B-C))
+println("The backward difference between slow plan and original: ", maxcolnorm(A-D))
+println("The backward difference between thin plan and original: ", maxcolnorm(A-E))
+println("The backward difference between slow and thin plans: ", maxcolnorm(D-E))

--- a/test/test_thinplan.jl
+++ b/test/test_thinplan.jl
@@ -1,4 +1,4 @@
-import FastTransforms: allranks
+import FastTransforms: allranks, normalizecolumns!, maxcolnorm
 
 n = 511
 

--- a/test/test_thinplan.jl
+++ b/test/test_thinplan.jl
@@ -1,6 +1,6 @@
 import FastTransforms: allranks, normalizecolumns!, maxcolnorm
 
-n = 511
+n = VERSION < v"0.6.0-" ? 255 : 511
 
 A = sphrandn(Float64, n+1, n+1);
 normalizecolumns!(A);

--- a/test/test_thinplan.jl
+++ b/test/test_thinplan.jl
@@ -9,7 +9,7 @@ C = zero(A);
 D = zero(A);
 E = zero(A);
 
-@time TP = ThinSphericalHarmonicPlan(A);
+@time TP = ThinSphericalHarmonicPlan(A; sketch = :none);
 @time SP = SlowSphericalHarmonicPlan(A);
 
 @time A_mul_B!(B, SP, A);


### PR DESCRIPTION
This adds Alpert & Rokhlin's Legendre-to-Chebyshev conversions via an adaptation of the Fast Multipole Method.

Using this [gist](https://gist.github.com/MikaelSlevinsky/09c43db2652d18a94483188a0099f373), the following error and timings plot compare and contrast the asymptotic, Toeplitz-dot-Hankel, and hierarchical methods. I propose that all methods be kept in the repository for future study.

![timings](https://cloud.githubusercontent.com/assets/8176037/24077312/157b1ec2-0c17-11e7-9895-99cc7a02f851.png)

![error](https://cloud.githubusercontent.com/assets/8176037/24077313/19f7525e-0c17-11e7-9123-d4931ecf123f.png)
