### PR TITLE
Change calculation of Chebyshev points of the second kind to be symme…

### DIFF
--- a/src/chebyshevtransform.jl
+++ b/src/chebyshevtransform.jl
@@ -294,7 +294,8 @@ function chebyshevpoints(::Type{T}, n::Integer; kind::Int=1) where T<:Number
         if n == 1
             zeros(T,1)
         else
-            T[cospi(k/(n-one(T))) for k=0:n-1]
+	    m = n - 1
+	    T[sinpi(k/(T(2)*m)) for k=m:-2:-m]
         end
     else
         throw(ArgumentError("kind $kind not a valid kind of Chebyshev points"))

--- a/src/chebyshevtransform.jl
+++ b/src/chebyshevtransform.jl
@@ -294,8 +294,7 @@ function chebyshevpoints(::Type{T}, n::Integer; kind::Int=1) where T<:Number
         if n == 1
             zeros(T,1)
         else
-	    m = n - 1
-	    T[sinpi(k/(T(2)*m)) for k=m:-2:-m]
+	    T[sinpi((n-2k-one(T))/(2n-2)) for k=0:n-1] 
         end
     else
         throw(ArgumentError("kind $kind not a valid kind of Chebyshev points"))


### PR DESCRIPTION
Use a sin based version to calculate the Chebyshev points of the 2nd kind that preserves their "symmetry". 
Current behavior:

'''
julia (v1.1)> chebyshevpoints(Float32, 4, kind=2)
4-element Array{Float32,1}:
  1.0       
  0.49999997
 -0.50000006
 -1.0       

julia (v1.1)> chebyshevpoints(Float64, 4, kind=2)
4-element Array{Float64,1}:
  1.0               
  0.5               
 -0.4999999999999999
 -1.0               
'''

New behavior

```
julia (v1.1)> chebyshevpoints(Float32, 4, kind=2)
4-element Array{Float32,1}:
  1.0
  0.5
 -0.5
 -1.0

julia (v1.1)> chebyshevpoints(Float64, 4, kind=2)
4-element Array{Float64,1}:
  1.0
  0.5
 -0.5
 -1.0
```
