### PR TITLE
Genericfft

### DIFF
--- a/test/fftBigFloattests.jl
+++ b/test/fftBigFloattests.jl
@@ -14,7 +14,7 @@ end
     @test norm(ifft(fft(c))-c) < 200norm(c)eps(BigFloat)
 
     p = plan_dct(c)
-    @test norm(dct(c) - p*c) == 0
+    @test norm(FastTransforms.generic_dct(c) - p*c) == 0
 
     pi = plan_idct!(c)
     @test norm(pi*dct(c) - c) < 1000norm(c)*eps(BigFloat)


### PR DESCRIPTION
This pull request makes the generic FFT and DCT routines in FastTransforms available for all AbstractFloats. Some changes to the codeflow are described in https://github.com/MikaelSlevinsky/FastTransforms.jl/issues/62. An earlier issue was #34.

The code is written such that the more efficient plans of FFTW are still returned when T is one of the fftwNumber types. There is currently no check for this, which is dangerous. I suppose we could check on the type of the plan returned by `plan_fft`, but I'm not sure how to check which method of `fft` ends up being invoked. I would not be surprised if this pull request breaks things. The implementation remains a *lot* slower than FFTW of course, and it is also less accurate.

My goal was to make it work for `DoubleFloats.jl` types, such as `Double64`. This works now:
```julia
julia> using FFTW, FastTransforms, DoubleFloats

julia> N = 10000; z = rand(N); z2 = Double64.(z); z3 = BigFloat.(z);

julia> v = fft(z); v2 = fft(z2); v3 = fft(z3);

julia> maximum(abs.(v-v2))
2.0438760310276306e-13

julia> maximum(abs.(v2-v3))
4.673372870301638733235131886202073426336931382556029192698665209605575831732632e-26

julia> @time fft(z);
  0.000491 seconds (58 allocations: 315.766 KiB)

julia> @time fft(z2);
  0.097739 seconds (548.98 k allocations: 33.332 MiB, 3.70% gc time)

julia> @time fft(z3);
  1.978109 seconds (17.87 M allocations: 952.290 MiB, 42.06% gc time)
```
So, for this example, `Double64` is faster than `BigFloat` by a factor of about 20. It is slower than FFTW by a factor of about 200.