### PR TITLE
Julia 1.12 support

### DIFF
--- a/test/libfasttransformstests.jl
+++ b/test/libfasttransformstests.jl
@@ -1,6 +1,6 @@
 using FastTransforms, Test
 
-FastTransforms.ft_set_num_threads(ceil(Int, Base.Sys.CPU_THREADS/2))
+FastTransforms.ft_set_num_threads(Base.Sys.CPU_THREADS ÷ 2)
 
 @testset "libfasttransforms" begin
     n = 64


### PR DESCRIPTION
This just shows that 

https://github.com/JuliaApproximation/FastTransforms.jl/issues/263

is present on non-macs as well.